### PR TITLE
feat: 무한 스크롤 구현

### DIFF
--- a/src/app/react-query/use-infinite-scroll.ts
+++ b/src/app/react-query/use-infinite-scroll.ts
@@ -1,0 +1,45 @@
+import { useInfiniteQuery } from "@tanstack/react-query";
+import { fetchMyActivities } from "../api/my-activities-api";
+import { fetchMyReservations } from "../api/my-reservations-api";
+import { fetchActivities } from "../api/activities-api";
+import { FindActivitiesQueryDto } from "../types/activity-schemas";
+
+export function useInfinityMyActivities() {
+  return useInfiniteQuery({
+    queryKey: ["activities"],
+    queryFn: ({ pageParam = 0 }) => {
+      return fetchMyActivities(pageParam, 10);
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage.cursorId || undefined;
+    },
+    initialPageParam: 0,
+  });
+}
+
+export const useInfiniteActivities = (filters: FindActivitiesQueryDto) => {
+  return useInfiniteQuery({
+    queryKey: ["activities", filters],
+    queryFn: ({ pageParam = 0 }) => {
+      const params = { ...filters, cursorId: pageParam };
+      return fetchActivities(params);
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage.cursorId || undefined;
+    },
+    initialPageParam: 0,
+  });
+};
+
+export const useInfiniteMyReservations = () => {
+  return useInfiniteQuery({
+    queryKey: ["infiniteMyReservations"],
+    queryFn: async ({ pageParam }) => {
+      return fetchMyReservations(pageParam);
+    },
+    getNextPageParam: (lastPage) => {
+      return lastPage.cursorId || undefined;
+    },
+    initialPageParam: 0,
+  });
+};


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 무한 스크롤 구현 완료 했습니다. (실제로 데이터를 불러와서 되는지 확인은 못했습니다.)
- 구현 내역
  - [x] 내 체험 리스트 조회
  - [x] 체험 리스트 조회
  - [x] 내 예약 리스트 조회
 
- 내 체험 날짜별 예약 정보 조회도 무한 스크롤로 구현하라고 노션에 적혀있었지만 api 자체가 모든 데이터를 한번에 불러오게 되어있어 굳이 무한스크롤 구현을 하지 않아도 되겠다고 판단했습니다.
