### PR TITLE
Refactor: 멘토링 피드백 반영 & 일부 오류 수정

### DIFF
--- a/src/app/react-query/activity-state.ts
+++ b/src/app/react-query/activity-state.ts
@@ -26,6 +26,7 @@ export const useActivities = (filters: FindActivitiesQueryDto) =>
   }>({
     queryKey: ["activities", filters],
     queryFn: async () => {
+      console.log("체험 리스트 조회 요청 필터:", filters);
       try {
         return await fetchActivities(filters);
       } catch (error) {

--- a/src/app/types/activity-schemas.ts
+++ b/src/app/types/activity-schemas.ts
@@ -1,10 +1,21 @@
 // Activity DTOs
+export const CATEGORY_TYPES = [
+  "문화 · 예술",
+  "식음료",
+  "스포츠",
+  "투어",
+  "관광",
+  "웰빙",
+] as const;
+
+export type CategoryType = (typeof CATEGORY_TYPES)[number];
+
 export interface ActivityBasicDto {
   id: number;
   userId: number;
   title: string;
   description: string;
-  category: "문화 · 예술" | "식음료" | "스포츠" | "투어" | "관광" | "웰빙";
+  category: CategoryType;
   price: number;
   address: string;
   bannerImageUrl: string;
@@ -24,7 +35,7 @@ export interface FindActivitiesQueryDto {
   size?: number;
 }
 
-export type CategoryType = Pick<FindActivitiesQueryDto, "category">["category"];
+// export type CategoryType = Pick<FindActivitiesQueryDto, "category">["category"];
 export type SortType = Pick<FindActivitiesQueryDto, "sort">["sort"];
 
 export interface ActivityWithSubImagesAndSchedulesDto {

--- a/src/components/common/layout/navigation/user-menu.tsx
+++ b/src/components/common/layout/navigation/user-menu.tsx
@@ -8,11 +8,9 @@ import UseOutsideClick from "@/hooks/use-outside-click";
 import { useAuth } from "@/app/api/use-auth";
 
 export default function UserMenu() {
-  const { user, isAuthenticated, logout, loading } = useAuth();
+  const { user, isAuthenticated, logout } = useAuth();
   const [isOpen, setIsOpen] = useState(false);
   const ref = UseOutsideClick(() => setIsOpen(false));
-
-  if (loading) return <></>;
 
   return (
     <>

--- a/src/components/common/layout/navigation/user-notifications.tsx
+++ b/src/components/common/layout/navigation/user-notifications.tsx
@@ -3,7 +3,7 @@
 import UseOutsideClick from "@/hooks/use-outside-click";
 import Image from "next/image";
 import { useState } from "react";
-import { foramtTime } from "@/utils/time-utils";
+import { formatTime } from "@/utils/time-utils";
 import { highlightText } from "@/utils/higlight-text";
 import { useDeleteNotification } from "@/app/react-query/notification-state";
 import { AxiosError } from "axios";
@@ -173,7 +173,7 @@ export default function UserNotifications() {
                         {highlightText(notification.content)}
                       </li>
                       <time className="text-xs font-regular text-gray-600">
-                        {foramtTime(notification.updatedAt)}
+                        {formatTime(notification.updatedAt)}
                       </time>
                     </div>
                   </div>

--- a/src/components/pages/home/all-activities/all-activities-section.tsx
+++ b/src/components/pages/home/all-activities/all-activities-section.tsx
@@ -9,26 +9,32 @@ import { useState } from "react";
 import { LoadingIndicator } from "@/components/common/layout/indicator/loading-indicator";
 import { ErrorIndicator } from "@/components/common/layout/indicator/error-indicator";
 import { CategoryType, SortType } from "@/app/types/activity-schemas";
+import { EmptyActivity } from "@/components/common/layout/profile/empty-activity";
+
+const SIZE = 8;
 
 export default function AllActivitiesSection() {
-  const size = 8;
   const [page, setPage] = useState(1);
-  const [category, setCategory] = useState<CategoryType>(undefined);
+  const [category, setCategory] = useState<CategoryType | undefined>(undefined);
   const [sort, setSort] = useState<SortType>(undefined);
 
   const { data, isLoading, isError } = useActivities({
     method: "offset",
     page,
-    size,
+    size: SIZE,
     sort: sort || "latest",
     category,
   });
 
-  const totalPages = Math.ceil((data?.totalCount || 0) / size);
+  const totalPages = Math.ceil((data?.totalCount || 0) / SIZE);
 
-  const handleFilterChange = (category: CategoryType, sort: SortType) => {
+  const handleFilterChange = (
+    category: CategoryType | undefined,
+    sort: SortType
+  ) => {
     setCategory(category);
     setSort(sort);
+    setPage(1);
   };
 
   return (
@@ -40,8 +46,12 @@ export default function AllActivitiesSection() {
         <LoadingIndicator width={80} height={80} />
       ) : isError ? (
         <ErrorIndicator width={80} height={80} />
-      ) : (
+      ) : (data?.activities?.length ?? 0 > 0) ? (
         <AllActivities activities={data?.activities || []} />
+      ) : (
+        <div className="m-[10rem]">
+          <EmptyActivity />
+        </div>
       )}
 
       <Pagination

--- a/src/components/pages/home/all-activities/category-price-filter.tsx
+++ b/src/components/pages/home/all-activities/category-price-filter.tsx
@@ -1,26 +1,22 @@
 import { useState } from "react";
 import Button from "../../../common/ui/button";
 import FilterDropdown from "../../../common/ui/dropdown/filter-dropdown";
-import { CategoryType, SortType } from "@/app/types/activity-schemas";
-
-const categories: CategoryType[] = [
-  "문화 · 예술",
-  "식음료",
-  "스포츠",
-  "투어",
-  "관광",
-  "웰빙",
-];
+import {
+  CATEGORY_TYPES,
+  CategoryType,
+  SortType,
+} from "@/app/types/activity-schemas";
 
 interface CategoryPriceFilterProps {
-  onFilterChange: (category: CategoryType, sort: SortType) => void;
+  onFilterChange: (category: CategoryType | undefined, sort: SortType) => void;
 }
 
 export default function CategoryPriceFilter({
   onFilterChange,
 }: CategoryPriceFilterProps) {
-  const [selectedCategory, setSelectedCategory] =
-    useState<CategoryType>(undefined);
+  const [selectedCategory, setSelectedCategory] = useState<
+    CategoryType | undefined
+  >(undefined);
   const [selectedSort, setSelectedSort] = useState<SortType>(undefined);
 
   const handleCategoryChange = (category: CategoryType) => {
@@ -41,9 +37,9 @@ export default function CategoryPriceFilter({
   return (
     <div className="flex-between gap-[1rem] w-[120rem]">
       <div className="flex-between gap-[2.4rem]">
-        {categories.map((category) => (
+        {CATEGORY_TYPES.map((category, index) => (
           <Button
-            key={category}
+            key={index}
             type="category"
             label={category}
             variant={category === selectedCategory ? "selected" : "category"}

--- a/src/components/pages/home/popular-activities/popular-activities-section.tsx
+++ b/src/components/pages/home/popular-activities/popular-activities-section.tsx
@@ -1,55 +1,20 @@
-"use client";
+// "use client";
 
 import { LoadingIndicator } from "@/components/common/layout/indicator/loading-indicator";
 import { ErrorIndicator } from "@/components/common/layout/indicator/error-indicator";
 import { useInfiniteActivities } from "@/app/react-query/use-infinite-scroll";
 import Image from "next/image";
-// import { useEffect, useRef, useState } from "react";
 import Link from "next/link";
 
-export default function PopularActivitiesSection() {
-  const size = 9;
+const SIZE = 9;
 
+export default function PopularActivitiesSection() {
   const { data, isLoading, isError } = useInfiniteActivities({
     method: "cursor",
     cursorId: null,
-    size,
+    size: SIZE,
     sort: "most_reviewed",
   });
-
-  //   const handleReachEnd = () => {
-  //     if (hasNextPage) {
-  //       fetchNextPage();
-  //     }
-  //   };
-
-  //   // 🔥 UI에서 현재 보고 있는 페이지를 관리
-  //   const [pageIndex, setPageIndex] = useState(0);
-
-  //   // 전체 데이터 가져오기
-  //   const activities = data?.pages.flatMap((page) => page.activities) || [];
-  //   const totalItems = activities.length;
-  //   const maxPageIndex = Math.ceil(totalItems / size) - 1; // 최대 페이지
-
-  //   // UI 상에서 다음 목록으로 이동
-  //   const handleNextCursor = () => {
-  //     if (pageIndex < maxPageIndex) {
-  //       setPageIndex((prev) => prev + 1);
-  //     }
-  //   };
-
-  //   // UI 상에서 이전 목록으로 이동
-  //   const handlePrevCursor = () => {
-  //     if (pageIndex > 0) {
-  //       setPageIndex((prev) => prev - 1);
-  //     }
-  //   };
-
-  //   // 🔥 현재 페이지에 해당하는 3개만 slice 해서 보여주기
-  //   const visibleActivities = activities.slice(
-  //     pageIndex * size,
-  //     (pageIndex + 1) * size
-  //   );
 
   const activities = data?.pages.flatMap((page) => page.activities) || [];
 
@@ -100,24 +65,16 @@ export default function PopularActivitiesSection() {
       ) : isError ? (
         <ErrorIndicator width={80} height={80} />
       ) : (
-        // <Swiper
-        //   slidesPerView={3}
-        //   spaceBetween={24}
-        //   loop={false}
-        //   onReachEnd={handleReachEnd}
-        // >
         <ul
           className="flex flex-nowrap gap-[2.4rem] w-[120rem] mb-[6rem] overflow-x-auto hide-scrollbar
     tablet:w-[80rem] tablet:px-[4rem] tablet:gap-[3.2rem]
     mobile:w-[38.8rem] mobile:mb-[4.6rem] mobile:px-[2rem] mobile:gap-[1.6rem]"
         >
           {activities.map((activity) => (
-            //   <SwiperSlide key={activity.id}>
             <li
               key={activity.id}
               className="relative h-[38.4rem] w-[38.4rem] border rounded-[2rem] flex-shrink-0 flex-grow-0
           mobile:w-[18.4rem] mobile:h-[18.4rem]"
-              // tablet:flex-shrink-0 mobile:flex-shrink-0
             >
               <Link href={`/activity/${activity.id}`}>
                 <Image
@@ -159,10 +116,8 @@ export default function PopularActivitiesSection() {
                 </div>
               </Link>
             </li>
-            //   </SwiperSlide>
           ))}
         </ul>
-        // </Swiper>
       )}
     </>
   );

--- a/src/components/pages/home/search/activity-explorer.tsx
+++ b/src/components/pages/home/search/activity-explorer.tsx
@@ -16,20 +16,25 @@ const isLastCharHasBatchim = (text: string): boolean => {
   if (!text) return false;
   const lastChar = text[text.length - 1];
   const unicode = lastChar.charCodeAt(0);
-  return (unicode - 44032) % 28 !== 0; // 받침이 있으면 true
+  return (unicode - 44032) % 28 !== 0;
+};
+
+const CONFIG = {
+  SIZE: 16,
+  SUFFIX_WITH_BATCHIM: "으로 ",
+  SUFFIX_WITHOUT_BATCHIM: "로 ",
 };
 
 export default function ActivityExplorer() {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [debouncedQuery] = useDebounce(searchQuery, 500);
   const [page, setPage] = useState(1);
-  const size = 16;
 
   const { data, isLoading, isError } = useActivities({
     method: "offset",
     page,
-    size,
-    keyword: debouncedQuery,
+    size: CONFIG.SIZE,
+    ...(debouncedQuery && { keyword: debouncedQuery }),
   });
 
   const handleSearchChange = (e: React.ChangeEvent<HTMLInputElement>) => {
@@ -43,9 +48,11 @@ export default function ActivityExplorer() {
 
   const activities = data?.activities ?? [];
 
-  const totalPages = Math.ceil((data?.totalCount || 0) / size);
+  const totalPages = Math.ceil((data?.totalCount || 0) / CONFIG.SIZE);
 
-  const suffix = isLastCharHasBatchim(searchQuery) ? "으로 " : "로 ";
+  const suffix = isLastCharHasBatchim(searchQuery)
+    ? CONFIG.SUFFIX_WITH_BATCHIM
+    : CONFIG.SUFFIX_WITHOUT_BATCHIM;
 
   return (
     <>

--- a/src/utils/time-utils.ts
+++ b/src/utils/time-utils.ts
@@ -1,9 +1,9 @@
-// import { formatDistanceToNowStrict } from "date-fns";
-// import { ko } from "date-fns/locale";
+import { formatDistanceToNowStrict } from "date-fns";
+import { ko } from "date-fns/locale";
 
-// export function foramtTime(dateString: string) {
-//   return formatDistanceToNowStrict(new Date(dateString), {
-//     addSuffix: true,
-//     locale: ko,
-//   });
-// }
+export function formatTime(dateString: string) {
+  return formatDistanceToNowStrict(new Date(dateString), {
+    addSuffix: true,
+    locale: ko,
+  });
+}


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
>
> ex) 와인 상세 페이지 컴포넌트 추가, 와인 데이터 API 호출 로직 추가, 상세 페이지 스타일 수정

- [x] category 타입 정적 생성 -> type 선언하고 import
- [x] 매직 넘버 수정
- [x] 상수 맨 위, 바깥으로 시프팅
- [x] 네비게이션 알림 목 데이터 CSS 뜨게 설정 다시 해놓음(기존에는 알림 클릭하면 오류 났음)
- [x] 페이지네이션 오류 해결(2페이지 누른 후, 1페이지 내용만 있는 카테고리 선택 시 return; 되고 1페이지를 다시 눌러야 렌더링 됐음 -> 이제 카테고리 누르면 자동으로 1페이지 이동)
- [x] 메인 페이지에서 가만 있어도 400 에러 뜬 거 수정(검색어가 없을 때, 빈 값 ""을 리퀘스트 바디에 보내서 오류가 났음 -> 검색어 없으면 리퀘스트 바디에 해당 옵션? 속성? 객체? 안 보내서 해결)

## 📸 스크린샷 / 영상


https://github.com/user-attachments/assets/e42cb580-f581-444a-ba8a-657342f4d40d



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
