### PR TITLE
Feat: 체험 상세 예약 기능 완료

### DIFF
--- a/src/app/react-query/activity-state.ts
+++ b/src/app/react-query/activity-state.ts
@@ -144,14 +144,17 @@ export const useReviews = ({ filters }: { filters: FindReviewsQueryDto }) => {
 // 체험 예약 가능일 조회
 export const useAvailableSchedules = ({
   filters,
+  enabled = true,
 }: {
   filters: FindAvailableScheduleQueryDto;
+  enabled?: boolean;
 }) => {
   const query = useQuery({
     queryKey: ["availableSchedules", filters],
     queryFn: () => fetchAvailableSchedules({ filters }),
     staleTime: 60 * 60 * 1000,
     retry: 1,
+    enabled,
   });
   if (query.isError) {
     console.error(query.error);

--- a/src/app/react-query/activity-state.ts
+++ b/src/app/react-query/activity-state.ts
@@ -144,17 +144,14 @@ export const useReviews = ({ filters }: { filters: FindReviewsQueryDto }) => {
 // 체험 예약 가능일 조회
 export const useAvailableSchedules = ({
   filters,
-  enabled = true,
 }: {
   filters: FindAvailableScheduleQueryDto;
-  enabled?: boolean;
 }) => {
   const query = useQuery({
     queryKey: ["availableSchedules", filters],
     queryFn: () => fetchAvailableSchedules({ filters }),
     staleTime: 60 * 60 * 1000,
     retry: 1,
-    enabled,
   });
   if (query.isError) {
     console.error(query.error);
@@ -162,7 +159,7 @@ export const useAvailableSchedules = ({
   return query;
 };
 
-// 체험 예약 생성
+// 체험 예약 신청
 export const useCreateReservation = () => {
   const queryClient = useQueryClient();
   return useMutation<

--- a/src/components/common/ui/booking-calendar.tsx
+++ b/src/components/common/ui/booking-calendar.tsx
@@ -1,6 +1,5 @@
-import { useAvailableSchedules } from "@/app/react-query/activity-state";
+import { ScheduleResponseDto } from "@/app/types/schedule-schemas";
 import Image from "next/image";
-import { useParams } from "next/navigation";
 import { useState } from "react";
 
 const DAYSOFWEEK = ["Sun", "Mon", "Tue", "Wed", "Thr", "Fri", "Sat"];
@@ -20,33 +19,25 @@ const MONTHS = [
 ];
 
 interface BookingCalendarProps {
-  onSelectDate: (day: Date) => void;
+  schedules?: ScheduleResponseDto[];
+  selectedDate: Date | null;
+  onSelectDate: (day: Date | null) => void;
 }
 
 export default function BookingCalendar({
+  schedules,
+  selectedDate,
   onSelectDate,
 }: BookingCalendarProps) {
   const today = new Date();
   const [currentYear, setCurrentYear] = useState(today.getFullYear());
   const [currentMonth, setCurrentMonth] = useState(today.getMonth()); // 0: 1월, 11: 12월
-  const [selectedDate, setSelectedDate] = useState(today);
-
-  const { id } = useParams();
-  const { data: schedules } = useAvailableSchedules({
-    filters: {
-      activityId: Number(id),
-      year: currentYear.toString(),
-      month: String(currentMonth + 1).padStart(2, "0"),
-    },
-  });
-
-  console.log("예약 가능일 조회용", id);
-  console.log("예약 가능일", schedules);
 
   const availableDates: string[] | undefined = schedules?.map(
     (schedule) => schedule.date
   );
 
+  console.log("예약 가능일", schedules);
   console.log("예약 가능일 배열", availableDates);
 
   // 📌 달력 데이터 생성 함수
@@ -88,13 +79,6 @@ export default function BookingCalendar({
   const handleNextMonth = () => {
     setCurrentMonth((prev) => (prev === 11 ? 0 : prev + 1));
     if (currentMonth === 11) setCurrentYear((prev) => prev + 1);
-  };
-
-  // 📌 날짜 선택 함수
-  const handleSelectDate = (day: number) => {
-    const selected = new Date(currentYear, currentMonth, day);
-    setSelectedDate(selected);
-    onSelectDate(selected);
   };
 
   return (
@@ -152,28 +136,35 @@ export default function BookingCalendar({
       <div className="grid grid-cols-7 w-[25rem]">
         {generateCalendar().map((day, index) => {
           // 현재 날짜가 예약 가능한 날짜인지 확인
-          const isAvailable: boolean =
-            availableDates?.includes(
-              `${currentYear}-${String(currentMonth + 1).padStart(2, "0")}-${String(day.date).padStart(2, "0")}`
-            ) ?? false;
+          const dateObj = new Date(currentYear, currentMonth, day.date);
+          if (!day.isCurrentMonth) {
+            dateObj.setMonth(currentMonth + (day.date > 15 ? -1 : 1));
+          }
+
+          const formattedDate = dateObj.toLocaleDateString("sv-SE"); // "YYYY-MM-DD" 포맷
+          const isAvailable = availableDates?.includes(formattedDate) ?? false;
+          const isSelected =
+            selectedDate &&
+            selectedDate.toDateString() === dateObj.toDateString();
 
           return (
             <button
               key={index}
               className={`h-[3.2rem] text-[1.3rem] leading-[1.77rem] p-[1rem] w-[3.571rem]
-                flex justify-center items-center rounded-[0.8rem] ${
-                  day.isCurrentMonth ? "text-gray-900" : "text-gray-600"
-                } ${
-                  !isAvailable
-                    ? "text-gray-200 cursor-not-allowed"
-                    : selectedDate.getDate() === day.date &&
-                        selectedDate.getMonth() === currentMonth
-                      ? "bg-green-dark text-white"
-                      : "hover:bg-green-light hover:text-green-dark"
+                flex justify-center items-center rounded-[0.8rem]
+                ${isAvailable ? "cursor-pointer text-gray-900" : "cursor-not-allowed text-gray-200"}
+                ${
+                  isAvailable && isSelected
+                    ? "bg-green-dark text-white"
+                    : isAvailable
+                      ? "hover:bg-green-light hover:text-green-dark"
+                      : ""
                 }`}
               onClick={(e) => {
                 e.preventDefault();
-                if (day.isCurrentMonth) handleSelectDate(day.date);
+                if (day.isCurrentMonth) {
+                  onSelectDate(dateObj);
+                }
               }}
             >
               {day.date}

--- a/src/components/common/ui/booking-calendar.tsx
+++ b/src/components/common/ui/booking-calendar.tsx
@@ -70,13 +70,33 @@ export default function BookingCalendar({
 
   // 📌 월 이동 함수
   const handlePrevMonth = () => {
-    setCurrentMonth((prev) => (prev === 0 ? 11 : prev - 1));
-    if (currentMonth === 0) setCurrentYear((prev) => prev - 1);
+    // 이전 달로 이동
+    const newMonth = currentMonth === 0 ? 11 : currentMonth - 1;
+    const newYear = currentMonth === 0 ? currentYear - 1 : currentYear;
+
+    // 이전 달의 1일 계산
+    const newDate = new Date(newYear, newMonth, 1);
+
+    setCurrentMonth(newMonth);
+    setCurrentYear(newYear);
+
+    // 부모에게 전달 (이전 달의 1일)
+    onSelectDate(newDate);
   };
 
   const handleNextMonth = () => {
-    setCurrentMonth((prev) => (prev === 11 ? 0 : prev + 1));
-    if (currentMonth === 11) setCurrentYear((prev) => prev + 1);
+    // 다음 달로 이동
+    const newMonth = currentMonth === 11 ? 0 : currentMonth + 1;
+    const newYear = currentMonth === 11 ? currentYear + 1 : currentYear;
+
+    // 다음 달의 1일 계산
+    const newDate = new Date(newYear, newMonth, 1);
+
+    setCurrentMonth(newMonth);
+    setCurrentYear(newYear);
+
+    // 부모에게 전달 (다음 달의 1일)
+    onSelectDate(newDate);
   };
 
   return (

--- a/src/components/common/ui/booking-calendar.tsx
+++ b/src/components/common/ui/booking-calendar.tsx
@@ -2,7 +2,7 @@ import { ScheduleResponseDto } from "@/app/types/schedule-schemas";
 import Image from "next/image";
 import { useState } from "react";
 
-const DAYSOFWEEK = ["Sun", "Mon", "Tue", "Wed", "Thr", "Fri", "Sat"];
+const DAYSOFWEEK = ["Sun", "Mon", "Tue", "Wed", "Thr", "Fri", "Sat"] as const;
 const MONTHS = [
   "January",
   "February",
@@ -16,12 +16,12 @@ const MONTHS = [
   "October",
   "November",
   "December",
-];
+] as const;
 
 interface BookingCalendarProps {
   schedules?: ScheduleResponseDto[];
-  selectedDate: Date | null;
-  onSelectDate: (day: Date | null) => void;
+  selectedDate: Date;
+  onSelectDate: (day: Date) => void;
 }
 
 export default function BookingCalendar({
@@ -33,9 +33,7 @@ export default function BookingCalendar({
   const [currentYear, setCurrentYear] = useState(today.getFullYear());
   const [currentMonth, setCurrentMonth] = useState(today.getMonth()); // 0: 1월, 11: 12월
 
-  const availableDates: string[] | undefined = schedules?.map(
-    (schedule) => schedule.date
-  );
+  const availableDates = schedules?.map((schedule) => schedule.date);
 
   console.log("예약 가능일", schedules);
   console.log("예약 가능일 배열", availableDates);
@@ -89,10 +87,11 @@ export default function BookingCalendar({
       {/* 📌 헤더 (월 변경 버튼) */}
       <div className="flex-between w-[25rem] mt-[1rem]">
         <button
-          onClick={(e) => {
-            e.preventDefault();
-            handlePrevMonth();
-          }}
+          type="button"
+          onClick={
+            // e.preventDefault();
+            handlePrevMonth
+          }
         >
           <Image
             src="/image/Prev.svg"
@@ -104,12 +103,7 @@ export default function BookingCalendar({
         <span className="font-bold text-md">
           {MONTHS[currentMonth]} {currentYear}
         </span>
-        <button
-          onClick={(e) => {
-            e.preventDefault();
-            handleNextMonth();
-          }}
-        >
+        <button type="button" onClick={handleNextMonth}>
           <Image
             src="/image/Next.svg"
             alt="다음 달 이동 버튼"

--- a/src/components/common/ui/modal/message-modal.tsx
+++ b/src/components/common/ui/modal/message-modal.tsx
@@ -1,3 +1,4 @@
+import UseOutsideClick from "@/hooks/use-outside-click";
 import React from "react";
 
 // 로그인 모달 인터페이스
@@ -18,6 +19,7 @@ export function MessageModal({ isOpen, onClose, message }: ModalProps) {
       <div
         className="bg-white w-[33.75rem] h-[15.625rem] rounded-[0.75rem] flex flex-col p-[1.5rem] shadow-lg"
         onClick={(e) => e.stopPropagation()}
+        ref={UseOutsideClick(onClose)}
       >
         <div className="flex-grow flex items-center justify-center">
           <p className="text-center text-[1.125rem] font-medium">{message}</p>

--- a/src/components/pages/activity-detail/booking-section.tsx
+++ b/src/components/pages/activity-detail/booking-section.tsx
@@ -14,9 +14,9 @@ export default function BookingSection() {
   const { data: activity } = useActivityDetail(Number(id));
 
   const [count, setCount] = useState(1);
-  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
+  const [selectedDate, setSelectedDate] = useState(new Date());
 
-  const handleDateChange = (day: Date | null) => {
+  const handleDateChange = (day: Date) => {
     setSelectedDate(day);
   };
 

--- a/src/components/pages/activity-detail/booking-section.tsx
+++ b/src/components/pages/activity-detail/booking-section.tsx
@@ -1,4 +1,7 @@
-import { useActivityDetail } from "@/app/react-query/activity-state";
+import {
+  useActivityDetail,
+  useAvailableSchedules,
+} from "@/app/react-query/activity-state";
 import BookingCalendar from "@/components/common/ui/booking-calendar";
 import Button from "@/components/common/ui/button";
 import Image from "next/image";
@@ -7,13 +10,37 @@ import { useState } from "react";
 
 export default function BookingSection() {
   const { id } = useParams();
+
   const { data: activity } = useActivityDetail(Number(id));
 
   const [count, setCount] = useState(1);
-  const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedDate, setSelectedDate] = useState<Date | null>(new Date());
+
+  const handleDateChange = (day: Date | null) => {
+    setSelectedDate(day);
+  };
+
+  const { data: schedules } = useAvailableSchedules({
+    filters: {
+      activityId: Number(id),
+      year: selectedDate ? selectedDate.getFullYear().toString() : "",
+      month: selectedDate
+        ? (selectedDate.getMonth() + 1).toString().padStart(2, "0")
+        : "",
+    },
+    enabled: !!selectedDate,
+  });
 
   const handleIncrease = () => setCount((prev) => prev + 1);
   const handleDecrease = () => setCount((prev) => Math.max(prev - 1, 1));
+
+  const availableTimes = selectedDate
+    ? schedules?.filter(
+        (schedule) =>
+          new Date(schedule.date).toLocaleDateString("sv-SE") ===
+          selectedDate.toLocaleDateString("sv-SE")
+      )
+    : [];
 
   return (
     <div
@@ -38,7 +65,11 @@ export default function BookingSection() {
           >
             <h2 className="text-xl font-bold">날짜</h2>
             <div className="ml-[1.6rem] mt-[1.6rem]">
-              <BookingCalendar onSelectDate={setSelectedDate} />
+              <BookingCalendar
+                schedules={schedules}
+                selectedDate={selectedDate}
+                onSelectDate={handleDateChange}
+              />
             </div>
           </div>
         </div>
@@ -55,15 +86,28 @@ export default function BookingSection() {
                   <div className="flex flex-col gap-[1.4rem]">
                     <h3 className="text-2lg font-bold">예약 가능한 시간</h3>
                     <div className="flex gap-[1.2rem] overflow-x-auto hide-scrollbar">
-                      {activity?.schedules.map((schedule) => (
-                        <Button
-                          key={schedule.id}
-                          ButtonType="availableTime"
-                          variant="category"
-                          label={`${schedule.startTime}~${schedule.endTime}`}
-                          className="flex-shrink-0"
-                        />
-                      ))}
+                      {availableTimes && availableTimes.length > 0 ? (
+                        availableTimes.map((schedule) =>
+                          schedule.times.map((time) => (
+                            <Button
+                              key={time.id}
+                              ButtonType="availableTime"
+                              variant="category"
+                              label={`${time.startTime}~${time.endTime}`}
+                              className="flex-shrink-0"
+                            />
+                          ))
+                        )
+                      ) : selectedDate ? (
+                        <span className="text-2lg">
+                          이 날짜에는 예약 가능한 시간이 없습니다.
+                        </span>
+                      ) : (
+                        <span className="text-2lg">
+                          날짜를 선택하면 해당 날짜의 예약 가능한 시간이
+                          조회됩니다
+                        </span>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/src/components/pages/activity-detail/booking-section.tsx
+++ b/src/components/pages/activity-detail/booking-section.tsx
@@ -42,6 +42,8 @@ export default function BookingSection() {
       )
     : [];
 
+  const [selectedTime, setSelectedTime] = useState<number | null>(null);
+
   return (
     <div
       className="border border-solid border-gray-300 rounded-[1.2rem]
@@ -92,9 +94,14 @@ export default function BookingSection() {
                             <Button
                               key={time.id}
                               ButtonType="availableTime"
-                              variant="category"
+                              variant={
+                                selectedTime === time.id
+                                  ? "selected"
+                                  : "category"
+                              }
                               label={`${time.startTime}~${time.endTime}`}
                               className="flex-shrink-0"
+                              onClick={() => setSelectedTime(time.id)}
                             />
                           ))
                         )

--- a/src/components/pages/activity-detail/booking-section.tsx
+++ b/src/components/pages/activity-detail/booking-section.tsx
@@ -1,20 +1,23 @@
 import {
   useActivityDetail,
   useAvailableSchedules,
+  useCreateReservation,
 } from "@/app/react-query/activity-state";
 import BookingCalendar from "@/components/common/ui/booking-calendar";
 import Button from "@/components/common/ui/button";
+import MessageModal from "@/components/common/ui/modal/message-modal";
 import Image from "next/image";
 import { useParams } from "next/navigation";
 import { useState } from "react";
 
 export default function BookingSection() {
   const { id } = useParams();
-
   const { data: activity } = useActivityDetail(Number(id));
 
-  const [count, setCount] = useState(1);
+  const [headCount, setHeadCount] = useState(1);
   const [selectedDate, setSelectedDate] = useState(new Date());
+  const [selectedTime, setSelectedTime] = useState(0);
+  const [isModalOpen, setIsModalOpen] = useState(false);
 
   const handleDateChange = (day: Date) => {
     setSelectedDate(day);
@@ -28,11 +31,10 @@ export default function BookingSection() {
         ? (selectedDate.getMonth() + 1).toString().padStart(2, "0")
         : "",
     },
-    enabled: !!selectedDate,
   });
 
-  const handleIncrease = () => setCount((prev) => prev + 1);
-  const handleDecrease = () => setCount((prev) => Math.max(prev - 1, 1));
+  const handleIncrease = () => setHeadCount((prev) => prev + 1);
+  const handleDecrease = () => setHeadCount((prev) => Math.max(prev - 1, 1));
 
   const availableTimes = selectedDate
     ? schedules?.filter(
@@ -42,7 +44,23 @@ export default function BookingSection() {
       )
     : [];
 
-  const [selectedTime, setSelectedTime] = useState<number | null>(null);
+  const totalPrice = (activity?.price ?? 1) * headCount;
+
+  const { mutate: createReservation } = useCreateReservation();
+
+  const isReservationAvailable = selectedTime > 0 && headCount > 0;
+
+  const handleBooking = () => {
+    const reservationData = {
+      scheduleId: selectedTime,
+      headCount,
+    };
+
+    createReservation(
+      { activityId: Number(id), reservationData },
+      { onSuccess: () => setIsModalOpen(true) }
+    );
+  };
 
   return (
     <div
@@ -142,8 +160,10 @@ export default function BookingSection() {
                       />
                     </button>
                     <input
-                      value={count}
-                      onChange={(e) => setCount(Number(e.target.value) || 1)}
+                      value={headCount}
+                      onChange={(e) =>
+                        setHeadCount(Number(e.target.value) || 1)
+                      }
                       className="w-[4rem] p-[0.6rem] text-md text-gray-900
                     font-regular text-center focus:outline-none"
                     />
@@ -165,7 +185,16 @@ export default function BookingSection() {
                 </div>
               </div>
               {/* 예약하기 버튼 */}
-              <Button ButtonType="reservation" type="submit" label="예약하기" />
+              <Button
+                ButtonType="reservation"
+                type="submit"
+                label="예약하기"
+                onClick={(e) => {
+                  e.preventDefault();
+                  handleBooking();
+                }}
+                disabled={!isReservationAvailable}
+              />
             </div>
           </div>
           {/* 총 합계 섹션 */}
@@ -173,12 +202,19 @@ export default function BookingSection() {
             <div className="flex-between">
               <h4 className="text-xl font-bold">총 합계</h4>
               <span className="text-xl font-bold">
-                ₩ {Number(activity?.price).toLocaleString("ko-KR")}
+                ₩ {Number(totalPrice).toLocaleString("ko-KR")}
               </span>
             </div>
           </div>
         </div>
       </form>
+      {isModalOpen && (
+        <MessageModal
+          onClose={() => setIsModalOpen(false)}
+          isOpen={isModalOpen}
+          message="예약이 완료되었습니다."
+        />
+      )}
     </div>
   );
 }


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
>
> ex) 와인 상세 페이지 컴포넌트 추가, 와인 데이터 API 호출 로직 추가, 상세 페이지 스타일 수정

- [x]  캘린더에서 특정 날짜를 선택하면 체크박스로 예약 가능한 시간을 선택할 수 있도록 하세요.
- [x]  한 번의 예약에는 한 타임만 예약이 가능하도록 하세요.
- [x]  예약 가능한 시간을 선택하지 않으면 '예약하기' 버튼이 활성화되지 않도록 하세요.
- [x]  참여 인원 기본 값은 1명으로 설정하세요.
- [x]  예약 가능한 시간을 선택하고 참여 인원수를 골라서 '예약하기' 버튼을 클릭하면 “예약이 완료되었습니다.” 모달창이 나타나도록 하세요.
- [x]  참여 인원수에 따라서 총합계 금액이 달라지도록 하세요.
- [x]  체험 후기는 페이지 네이션으로 정렬되도록 하세요.

## 📸 스크린샷 / 영상


https://github.com/user-attachments/assets/5c99e703-99b9-4ae4-b51b-9bb3bfd1f197



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 코드가 좀 지저분하긴 한데..당장은 리팩토링 할 힘과 지식이 없습니다..마음만 급해서 계속 꼬이고 시간만 잡아먹었네요 ㅜ
