### PR TITLE
Features/188 체험 등록 수정 멘토링 피드백 적용

### DIFF
--- a/src/app/profile/my-activities/post/page.tsx
+++ b/src/app/profile/my-activities/post/page.tsx
@@ -13,6 +13,7 @@ import BannerImageUploader from "../../../../components/pages/activity-post-edit
 import IntroImagesUploader from "../../../../components/pages/activity-post-edit/intro-image-uploader";
 import { useCreateActivity } from "@/app/react-query/activity-state";
 import MessageModal from "@/components/common/ui/modal/message-modal";
+import KakaoMapAddress from "@/components/pages/activity-post-edit/kakao-map-address";
 
 type ReservationAvailableTime = {
   date: string;
@@ -198,19 +199,7 @@ export default function ActivityPostPage() {
 
           <label className="flex flex-col gap-[1.6rem]">
             <div className="font-pretendard text-2xl font-bold">주소</div>
-            <div>
-              <input
-                type="text"
-                placeholder="주소를 입력해주세요."
-                className="w-[79.2rem] tablet:w-[42.9rem] mobile:w-[34.3rem] h-[5.6rem] rounded-[0.4rem] border-black border-[0.1rem] p-[1.6rem] text-lg font-normal"
-                {...register("address", { required: "주소를 입력해주세요." })}
-              />
-              {errors.address && (
-                <p className="text-red-500 text-sm mt-2">
-                  {errors.address.message}
-                </p>
-              )}
-            </div>
+            <KakaoMapAddress />
           </label>
 
           <div ref={reservationRef} tabIndex={-1}>

--- a/src/app/profile/my-activities/post/page.tsx
+++ b/src/app/profile/my-activities/post/page.tsx
@@ -118,7 +118,13 @@ export default function ActivityPostPage() {
               type="text"
               placeholder="제목"
               className="w-[79.2rem] tablet:w-[42.9rem] mobile:w-[34.3rem] h-[5.6rem] rounded-[0.4rem] border-black border-[0.1rem] p-[1.6rem] text-lg font-normal"
-              {...register("title", { required: "제목을 입력해주세요." })}
+              {...register("title", {
+                required: "제목을 입력해주세요.",
+                maxLength: {
+                  value: 20,
+                  message: "제목은 최대 20자까지 입력할 수 있습니다.",
+                },
+              })}
             />
             {errors.title && (
               <p className="text-red-500 text-sm mt-2">

--- a/src/app/profile/my-activities/post/page.tsx
+++ b/src/app/profile/my-activities/post/page.tsx
@@ -171,7 +171,14 @@ export default function ActivityPostPage() {
                 className="w-[79.2rem] tablet:w-[42.9rem] mobile:w-[34.3rem] h-[5.6rem] rounded-[0.4rem] border-black border-[0.1rem] p-[1.6rem] text-lg font-normal"
                 {...register("price", {
                   required: "가격을 입력해주세요.",
-                  min: { value: 1, message: "가격은 1 이상이어야 합니다." },
+                  min: {
+                    value: 1000,
+                    message: "가격은 1000원 이상이어야 합니다.",
+                  },
+                  max: {
+                    value: 1000000,
+                    message: "가격은 100만원 이하이어야 합니다.",
+                  },
                   valueAsNumber: true,
                 })}
               />

--- a/src/components/pages/activity-post-edit/date-selector.tsx
+++ b/src/components/pages/activity-post-edit/date-selector.tsx
@@ -3,7 +3,7 @@ import Image from "next/image";
 
 type DateSelectorProps = {
   selectedDate: string;
-  onDateChange: (formattedDate: string, rawDate: string) => void;
+  onDateChange: (rawDate: string) => void;
 };
 
 const DateSelector: React.FC<DateSelectorProps> = ({
@@ -22,12 +22,8 @@ const DateSelector: React.FC<DateSelectorProps> = ({
     const dateValue = e.target.value;
     if (!dateValue) return;
 
-    const [year, month, day] = dateValue.split("-");
-    const shortYear = year.slice(2);
-    const formattedDate = `${shortYear}/${month}/${day}`;
-
     setRawDate(dateValue);
-    onDateChange(formattedDate, dateValue);
+    onDateChange(dateValue);
   };
 
   return (

--- a/src/components/pages/activity-post-edit/kakao-map-address.tsx
+++ b/src/components/pages/activity-post-edit/kakao-map-address.tsx
@@ -1,0 +1,147 @@
+"use client";
+import { useEffect } from "react";
+import { useFormContext } from "react-hook-form";
+
+// Kakao API 관련 타입 선언
+type LatLng = { lat: number; lng: number };
+type MapOptions = { center: LatLng; level: number };
+type Map = {
+  setCenter(latlng: LatLng): void;
+  relayout(): void;
+  getCenter(): LatLng;
+};
+type MarkerOptions = { position: LatLng; map: Map };
+type Marker = { setPosition(latlng: LatLng): void };
+type Geocoder = {
+  addressSearch(
+    address: string,
+    callback: (result: GeocoderResult[], status: string) => void
+  ): void;
+};
+type GeocoderResult = { address_name: string; x: string; y: string };
+type DaumPostcode = { open(): void };
+type Kakao = {
+  maps: {
+    LatLng: new (lat: number, lng: number) => LatLng;
+    Map: new (container: HTMLElement, options: MapOptions) => Map;
+    Marker: new (options: MarkerOptions) => Marker;
+    services: { Geocoder: new () => Geocoder; Status: { OK: string } };
+  };
+};
+
+declare global {
+  interface Window {
+    kakaoMapsAPI?: Kakao;
+    daum?: {
+      Postcode: new (options: {
+        oncomplete: (data: AddressData) => void;
+      }) => DaumPostcode;
+    };
+  }
+}
+
+interface AddressData {
+  address: string;
+}
+
+export default function KakaoMapAddress() {
+  const {
+    register,
+    setValue,
+    formState: { errors },
+  } = useFormContext();
+
+  const loadPostcode = () => {
+    if (!window.daum) {
+      const script = document.createElement("script");
+      script.src =
+        "//t1.daumcdn.net/mapjsapi/bundle/postcode/prod/postcode.v2.js";
+      script.async = true;
+      script.onload = () => sample5_execDaumPostcode();
+      document.head.appendChild(script);
+    } else {
+      sample5_execDaumPostcode();
+    }
+  };
+
+  const sample5_execDaumPostcode = () => {
+    if (!window.daum?.Postcode) {
+      alert(
+        "주소 검색 API가 아직 로드되지 않았습니다. 잠시 후 다시 시도해주세요."
+      );
+      return;
+    }
+    new window.daum.Postcode({
+      oncomplete: (data: AddressData) => {
+        const addr = data.address;
+        setValue("address", addr, { shouldValidate: true });
+        if (window.kakaoMapsAPI && window.kakaoMapsAPI.maps) {
+          // undefined 체크
+          const geocoder = new window.kakaoMapsAPI.maps.services.Geocoder();
+          geocoder.addressSearch(addr, (results, status) => {
+            if (status === window.kakaoMapsAPI!.maps.services.Status.OK) {
+              // Non-null 단언
+              const result = results[0];
+              const coords = new window.kakaoMapsAPI!.maps.LatLng(
+                Number(result.y),
+                Number(result.x)
+              );
+              const mapContainer = document.getElementById(
+                "map"
+              ) as HTMLElement;
+              const map = new window.kakaoMapsAPI!.maps.Map(mapContainer, {
+                center: coords,
+                level: 5,
+              });
+              const marker = new window.kakaoMapsAPI!.maps.Marker({
+                position: coords,
+                map: map,
+              });
+              mapContainer.style.display = "block";
+              map.relayout();
+              map.setCenter(coords);
+              marker.setPosition(coords);
+            }
+          });
+        }
+      },
+    }).open();
+  };
+
+  useEffect(() => {
+    if (!window.kakaoMapsAPI) {
+      const script = document.createElement("script");
+      script.src = `//dapi.kakao.com/v2/maps/sdk.js?appkey=YOUR_API_KEY&libraries=services`;
+      script.async = true;
+      script.onload = () => {
+        window.kakaoMapsAPI = window.kakao; // kakao 객체 할당
+      };
+      document.head.appendChild(script);
+    }
+  }, []);
+
+  return (
+    <div>
+      <input
+        type="text"
+        placeholder="주소를 입력해주세요."
+        className="w-[79.2rem] tablet:w-[42.9rem] mobile:w-[34.3rem] h-[5.6rem] rounded-[0.4rem] border-black border-[0.1rem] p-[1.6rem] text-lg font-normal"
+        {...register("address", { required: "주소를 입력해주세요." })}
+        onClick={loadPostcode}
+        readOnly
+      />
+      {typeof errors.address?.message === "string" && (
+        <p className="text-red-500 text-sm mt-2">{errors.address.message}</p>
+      )}
+      <div
+        id="map"
+        style={{
+          width: "100%",
+          height: "300px",
+          marginTop: "10px",
+          display: "none",
+        }}
+      ></div>
+    </div>
+  );
+}

--- a/src/components/pages/activity-post-edit/set-reservation-time.tsx
+++ b/src/components/pages/activity-post-edit/set-reservation-time.tsx
@@ -35,6 +35,8 @@ export default function ReservationTimeSelector({
     useState<string[]>(TIME_TABLE);
   const [errorMessage, setErrorMessage] = useState("");
 
+  const filterStartTimeOptions = TIME_TABLE.slice(0, -1);
+
   // 시작 시간 선택 시, 종료 시간 옵션 필터링
   useEffect(() => {
     if (newReservationTime.startTime) {
@@ -128,7 +130,7 @@ export default function ReservationTimeSelector({
                   시작 시간
                 </label>
                 <TimeDropdown
-                  options={TIME_TABLE}
+                  options={filterStartTimeOptions}
                   description="0:00"
                   selectedOption={newReservationTime.startTime}
                   onSelect={(startTime) =>

--- a/src/components/pages/activity-post-edit/set-reservation-time.tsx
+++ b/src/components/pages/activity-post-edit/set-reservation-time.tsx
@@ -120,7 +120,7 @@ export default function ReservationTimeSelector({
           <div className="flex flex-row gap-[2rem] tablet:gap-[0.5rem] mobile:gap-[0.4rem]">
             <DateSelector
               selectedDate={newReservationTime.date}
-              onDateChange={(formattedDate, rawDate) =>
+              onDateChange={(rawDate) =>
                 setNewReservationTime({ ...newReservationTime, date: rawDate })
               }
             />

--- a/src/components/pages/activity-post-edit/set-reservation-time.tsx
+++ b/src/components/pages/activity-post-edit/set-reservation-time.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import TimeDropdown from "./time-dropdown";
 import Button from "@/components/common/ui/button";
 import { TIME_TABLE } from "../../../app/profile/my-activities/post/_constants/constants";
@@ -31,7 +31,28 @@ export default function ReservationTimeSelector({
       endTime: "",
     });
 
+  const [filteredEndTimeOptions, setFilteredEndTimeOptions] =
+    useState<string[]>(TIME_TABLE);
   const [errorMessage, setErrorMessage] = useState("");
+
+  // 시작 시간 선택 시, 종료 시간 옵션 필터링
+  useEffect(() => {
+    if (newReservationTime.startTime) {
+      const startTimeIndex = TIME_TABLE.indexOf(newReservationTime.startTime);
+      const filteredOptions = TIME_TABLE.slice(startTimeIndex + 1);
+      setFilteredEndTimeOptions(filteredOptions);
+
+      if (
+        newReservationTime.endTime &&
+        !filteredOptions.includes(newReservationTime.endTime)
+      ) {
+        setNewReservationTime((prev) => ({ ...prev, endTime: "" }));
+      }
+    } else {
+      setFilteredEndTimeOptions(TIME_TABLE);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [newReservationTime.startTime]);
 
   const addReservationTime = () => {
     if (
@@ -125,7 +146,7 @@ export default function ReservationTimeSelector({
                   종료 시간
                 </label>
                 <TimeDropdown
-                  options={TIME_TABLE}
+                  options={filteredEndTimeOptions} // 필터링된 옵션 전달
                   description="0:00"
                   selectedOption={newReservationTime.endTime}
                   onSelect={(endTime) =>
@@ -164,7 +185,6 @@ export default function ReservationTimeSelector({
                   : ""
               }
             />
-
             <div className="flex flex-row gap-[1.2rem] tablet:gap-[0.5rem] mobile:gap-[0.4rem]">
               <input
                 type="text"
@@ -177,7 +197,6 @@ export default function ReservationTimeSelector({
                   ~
                 </div>
               </div>
-
               <input
                 type="text"
                 className="w-[14rem] tablet:w-[10.4rem] mobile:w-[7.9rem] h-[5.6rem] mobile:h-[4.4rem] rounded-[0.4rem] border-black border-[0.1rem] p-[1.6rem] text-lg font-normal"


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
>
> ex) 와인 상세 페이지 컴포넌트 추가, 와인 데이터 API 호출 로직 추가, 상세 페이지 스타일 수정

- 체험 등록 / 수정 페이지
  - 시작 시간에 따라 종료 시간 변경
    - 시작 시간이 10:00면 종료 시간 옵션은 10:30분부터 나오도록 설정
    - 시작 시간과 종료 시간이 전부 설정 되어있을 때, 시작 시간을 종료 시간과 같은 시간이나 뒷 시간으로 설정하면 종료 시간이 초기화 되도록 설정했습니다.
    - 시작 시간은 TIME_TABLE 배열의 마지막 배열은 옵션에 추가하지 않도록 했습니다(시작 시간 옵션: ~ 20:30, 종료 시간 옵션: ~ 21:00)
  - 최소 가격 최대 가격 설정
    - 최소 가격: 1000원
    - 최대 가격: 1000000원
    - 해당 가격보다 낮거나 높으면, 등록하기 버튼이 활성화가 되지 않고 에러 메시지가 input 아래에 표시됩니다.
  - 체험 제목 글자수 제한
    - 체험 제목 글자수를 20자로 제한했습니다.
    - 최대 최소 가격 설정과 동일하게 해당 글자수를 초과하면 등록하기 버튼이 활성화 되지 않고 에러 메시지가 input 아래에 표시됩니다.
  - 주소 - 우편 번호 서비스
    - https://postcode.map.daum.net/guide
    - 주소찾기 오픈api를 사용해서 구현했습니다.
    - 이 부분은 gpt의 도움을 매우 많이 받아 구현되었습니다.

## 📸 스크린샷 / 영상
제목 20자 이상 
![image](https://github.com/user-attachments/assets/600899b7-04c5-458d-8be0-173654c2790c)

가격 1000원 이하
![image](https://github.com/user-attachments/assets/63a4c642-95b8-4b31-9508-f43d6851f47f)

가격 1,000,000원 이상
![image](https://github.com/user-attachments/assets/42e374e3-58c7-49c6-805e-90a308eb8b1e)

예약 가능 시간 시작 시간 설정 시 종료 시간 배열 변경
![image](https://github.com/user-attachments/assets/60c4ea2c-54ec-425d-b464-e254556d8e3c)

예약 가능 시간에서 시작 시간을 종료시간과 같거나 뒷시간으로 설정했을 때
![image](https://github.com/user-attachments/assets/915ff7a3-7fb3-4fda-bfe7-8df2d3027c62)
![image](https://github.com/user-attachments/assets/35b3c692-956d-4263-b3f0-e635a71eeb6d)

주소 input 클릭 시 팝업
![image](https://github.com/user-attachments/assets/e3f8990e-64f8-4b19-a1f7-a9c908ae82b2)

주소 등록 후 체험 상세
![image](https://github.com/user-attachments/assets/4f12b5e6-fb3d-40aa-ba87-7c21eaab7aaa)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
