### PR TITLE
feat: 이미지 파일 확장자 제한

### DIFF
--- a/src/components/pages/activity-post-edit/banner-image-uploader.tsx
+++ b/src/components/pages/activity-post-edit/banner-image-uploader.tsx
@@ -65,7 +65,7 @@ export default function BannerImageUploader({
           <label className="cursor-pointer w-[18rem] tablet:w-[20.4rem] mobile:w-[16.7rem] h-[18rem] tablet:h-[20.4rem] mobile:h-[16.7rem]">
             <input
               type="file"
-              accept="image/*"
+              accept="image/png, image/jpg"
               onChange={handleBannerUpload}
               className="hidden"
             />
@@ -78,6 +78,9 @@ export default function BannerImageUploader({
           </label>
         )}
       </div>
+      <p className="text-sm text-gray-500">
+        *이미지는 png, jpg, jpeg 확장자만 등록 가능합니다.
+      </p>
     </div>
   );
 }

--- a/src/components/pages/activity-post-edit/banner-image-uploader.tsx
+++ b/src/components/pages/activity-post-edit/banner-image-uploader.tsx
@@ -65,7 +65,7 @@ export default function BannerImageUploader({
           <label className="cursor-pointer w-[18rem] tablet:w-[20.4rem] mobile:w-[16.7rem] h-[18rem] tablet:h-[20.4rem] mobile:h-[16.7rem]">
             <input
               type="file"
-              accept="image/png, image/jpg"
+              accept="image/png, image/jpeg"
               onChange={handleBannerUpload}
               className="hidden"
             />

--- a/src/components/pages/activity-post-edit/intro-image-uploader.tsx
+++ b/src/components/pages/activity-post-edit/intro-image-uploader.tsx
@@ -42,7 +42,7 @@ export default function IntroImagesUploader({
         <label className="cursor-pointer w-[18rem] tablet:w-[20.4rem] mobile:w-[16.7rem] h-[18rem] tablet:h-[20.4rem] mobile:h-[16.7rem]">
           <input
             type="file"
-            accept="image/png, image/jpg"
+            accept="image/png, image/jpeg"
             multiple
             onChange={handleIntroUpload}
             className="hidden"

--- a/src/components/pages/activity-post-edit/intro-image-uploader.tsx
+++ b/src/components/pages/activity-post-edit/intro-image-uploader.tsx
@@ -42,7 +42,7 @@ export default function IntroImagesUploader({
         <label className="cursor-pointer w-[18rem] tablet:w-[20.4rem] mobile:w-[16.7rem] h-[18rem] tablet:h-[20.4rem] mobile:h-[16.7rem]">
           <input
             type="file"
-            accept="image/*"
+            accept="image/png, image/jpg"
             multiple
             onChange={handleIntroUpload}
             className="hidden"


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 배너 이미지와 인트로 이미지들의 등록 가능 확장자를 제한 시켰습니다.
- png, jpg, jpeg
- 추가로 등록 가능 확장자를 알 수 있도록 문구를 추가했습니다.

## 📸 스크린샷 / 영상
![image](https://github.com/user-attachments/assets/97d7c6d7-be70-4357-af4f-cc6604c3b8a8)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
