### PR TITLE
feat: useCanDelete훅 리팩토링

### DIFF
--- a/src/app/api/my-activities-api.ts
+++ b/src/app/api/my-activities-api.ts
@@ -24,15 +24,20 @@ export const fetchMonthlyReservationStats = async (
   year: string,
   month: string
 ) => {
-  const response = await instance.get<
-    {
-      date: string;
-      reservations: { completed: number; confirmed: number; pending: number };
-    }[]
-  >(`/my-activities/${activityId}/reservation-dashboard`, {
-    params: { year, month },
-  });
-  return response.data;
+  try {
+    const response = await instance.get<
+      {
+        date: string;
+        reservations: { completed: number; confirmed: number; pending: number };
+      }[]
+    >(`/my-activities/${activityId}/reservation-dashboard`, {
+      params: { year, month },
+    });
+    return response.data || [];
+  } catch (error) {
+    console.error("Failed to fetch reservation stats:", error);
+    return [];
+  }
 };
 
 // 내 체험 날짜별 예약 정보 조회

--- a/src/hooks/use-can-delete-activity.ts
+++ b/src/hooks/use-can-delete-activity.ts
@@ -1,36 +1,36 @@
-import { useState, useEffect } from "react";
-import { useMonthlyReservationStats } from "@/app/react-query/my-activity-state";
+import { useQuery } from "@tanstack/react-query";
+import { fetchMonthlyReservationStats } from "@/app/api/my-activities-api";
+
+async function fetchSixMonthsStats(activityId: number) {
+  const promises = [];
+  const currentDate = new Date();
+
+  for (let i = 0; i < 6; i++) {
+    const date = new Date(
+      currentDate.getFullYear(),
+      currentDate.getMonth() - i,
+      1
+    );
+    const year = date.getFullYear().toString();
+    const month = (date.getMonth() + 1).toString().padStart(2, "0");
+
+    promises.push(fetchMonthlyReservationStats(activityId, year, month));
+  }
+
+  const results = await Promise.all(promises);
+  return results.flat();
+}
 
 export function useCanDeleteActivity(activityId: number) {
-  const { data: monthlyStats, isLoading } = useMonthlyReservationStats(
-    activityId,
-    new Date().getFullYear().toString(),
-    (new Date().getMonth() + 1).toString().padStart(2, "0")
-  );
-
-  const [canDelete, setCanDelete] = useState(false);
-
-  useEffect(() => {
-    if (!monthlyStats) return;
-
-    let hasPending = false;
-    let hasApproved = false;
-
-    monthlyStats.forEach((stat) => {
-      if (stat.reservations.pending > 0) {
-        hasPending = true;
-      }
-      if (stat.reservations.confirmed > 0) {
-        hasApproved = true;
-      }
-    });
-
-    if (hasPending || hasApproved) {
-      setCanDelete(false); // 삭제 불가능
-    } else {
-      setCanDelete(true); // 삭제 가능
-    }
-  }, [monthlyStats]);
+  const { data: canDelete, isLoading } = useQuery({
+    queryKey: ["reservationStats", activityId, "6months"],
+    queryFn: () => fetchSixMonthsStats(activityId),
+    select: (stats) =>
+      !stats.some(
+        (stat: { reservations: { pending: number; confirmed: number } }) =>
+          stat.reservations.pending > 0 || stat.reservations.confirmed > 0
+      ),
+  });
 
   return { canDelete, isLoading };
 }

--- a/src/hooks/use-can-delete-activity.ts
+++ b/src/hooks/use-can-delete-activity.ts
@@ -1,30 +1,24 @@
 import { useQuery } from "@tanstack/react-query";
 import { fetchMonthlyReservationStats } from "@/app/api/my-activities-api";
 
-async function fetchSixMonthsStats(activityId: number) {
-  const promises = [];
+async function fetchOneMonthStats(activityId: number) {
   const currentDate = new Date();
+  const year = currentDate.getFullYear().toString();
+  const month = (currentDate.getMonth() + 1).toString().padStart(2, "0");
 
-  for (let i = 0; i < 6; i++) {
-    const date = new Date(
-      currentDate.getFullYear(),
-      currentDate.getMonth() - i,
-      1
-    );
-    const year = date.getFullYear().toString();
-    const month = (date.getMonth() + 1).toString().padStart(2, "0");
-
-    promises.push(fetchMonthlyReservationStats(activityId, year, month));
+  try {
+    const stats = await fetchMonthlyReservationStats(activityId, year, month);
+    return stats;
+  } catch (error) {
+    console.error("Failed to fetch reservation stats:", error);
+    return [];
   }
-
-  const results = await Promise.all(promises);
-  return results.flat();
 }
 
 export function useCanDeleteActivity(activityId: number) {
   const { data: canDelete, isLoading } = useQuery({
-    queryKey: ["reservationStats", activityId, "6months"],
-    queryFn: () => fetchSixMonthsStats(activityId),
+    queryKey: ["reservationStats", activityId, "1month"],
+    queryFn: () => fetchOneMonthStats(activityId),
     select: (stats) =>
       !stats.some(
         (stat: { reservations: { pending: number; confirmed: number } }) =>


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- useCanDelete훅을 리팩토링 했습니다
- 바뀐 점
  - select 옵션을 추가하기 위해 useMonthlyReservationStats를 사용하지 않고 새로 useQuery를 활용하여 새로운 훅을 만들었습니다. (예약 현황 페이지에 사용해야되기 때문에 건드리기 좀 그래서 새로 만들었습니다.)
  - useState와 useEffect를 사용한다. -> select 옵션을 사용하여 불필요한 리렌더링을 방지

- 아직 api 활용하는게 잘 안되서 gpt 도움을 많이 받았습니다.
- 월별 예약 현황을 불러와 삭제가 가능한지 해당 월의 예약 목록을 살펴보는데 1개월은 너무 적은 것 같아 6개월(6번)을 받아오게 코드를 짰습니다. 
- 생각해보면 체험 하나에 6번이면 내 체험 목록 페이지 들어가면 한번에 60번을 받아오는건데... 생각을 못했네요. 우선 1개월로 해두고 더 수정할 수 있는 방법이 있는지 찾아보겠습니다.

## 📸 스크린샷 / 영상

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
