### PR TITLE
feat: 체험에 예약된 시간이 하나라도 있다면 해당 체험 수정이 불가능한 현상 수정

### DIFF
--- a/src/app/(primary)/profile/my-activities/[id]/edit/page.tsx
+++ b/src/app/(primary)/profile/my-activities/[id]/edit/page.tsx
@@ -18,12 +18,13 @@ import MessageModal from "@/components/common/ui/modal/message-modal";
 import { useUpdateMyActivity } from "@/app/react-query/my-activity-state";
 
 type ReservationAvailableTime = {
+  id?: number;
   date: string;
   startTime: string;
   endTime: string;
 };
 
-export default function ActivityPostPage() {
+export default function ActivityEditPage() {
   const { id } = useParams();
   const activityId = Number(id);
   const { data: activityDetail, isLoading } = useActivityDetail(activityId);
@@ -40,15 +41,19 @@ export default function ActivityPostPage() {
     },
   });
 
-  const [modalIsOpen, setModalIsOpen] = useState(false);
-  const [bannerImage, setBannerImage] = useState<string | null>(null);
-  const [introImages, setIntroImages] = useState<string[]>([]);
-  const [reservationTimes, setReservationTimes] = useState<
+  // 기존 API 예약 시간과 새로 추가할 예약 시간을 분리합니다.
+  const [existingReservationTimes, setExistingReservationTimes] = useState<
+    ReservationAvailableTime[]
+  >([]);
+  const [addedReservationTimes, setAddedReservationTimes] = useState<
     ReservationAvailableTime[]
   >([]);
   const [removedReservationIds, setRemovedReservationIds] = useState<number[]>(
     []
   );
+  const [bannerImage, setBannerImage] = useState<string | null>(null);
+  const [introImages, setIntroImages] = useState<string[]>([]);
+  const [modalIsOpen, setModalIsOpen] = useState(false);
 
   const {
     register,
@@ -67,6 +72,7 @@ export default function ActivityPostPage() {
       setBannerImage(activityDetail.bannerImageUrl);
       setIntroImages(activityDetail.subImages.map((img) => img.imageUrl));
 
+      // 기존 예약 시간은 따로 관리
       const initialReservationTimes = activityDetail.schedules.map(
         (schedule) => ({
           id: schedule.id,
@@ -75,13 +81,7 @@ export default function ActivityPostPage() {
           endTime: schedule.endTime,
         })
       );
-
-      setReservationTimes(initialReservationTimes);
-
-      const initialRemovedIds = initialReservationTimes
-        .map((time) => time.id)
-        .filter((id): id is number => id !== undefined);
-      setRemovedReservationIds(initialRemovedIds);
+      setExistingReservationTimes(initialReservationTimes);
     }
   }, [activityDetail, setValue]);
 
@@ -90,7 +90,7 @@ export default function ActivityPostPage() {
       alert("배너 이미지를 등록해주세요.");
       return;
     }
-    if (reservationTimes.length === 0) {
+    if (existingReservationTimes.length + addedReservationTimes.length === 0) {
       alert("예약 가능한 시간대를 추가해주세요.");
       return;
     }
@@ -103,11 +103,14 @@ export default function ActivityPostPage() {
       address: data.address,
       bannerImageUrl: bannerImage,
       subImageUrlsToAdd: introImages,
-      schedulesToAdd: reservationTimes.map(({ date, startTime, endTime }) => ({
-        date,
-        startTime,
-        endTime,
-      })),
+      // 새로 추가된 예약 시간만 schedulesToAdd에 포함
+      schedulesToAdd: addedReservationTimes.map(
+        ({ date, startTime, endTime }) => ({
+          date,
+          startTime,
+          endTime,
+        })
+      ),
       scheduleIdsToRemove: removedReservationIds,
     };
 
@@ -150,7 +153,12 @@ export default function ActivityPostPage() {
               ButtonType="profileSave"
               label="수정하기"
               type="submit"
-              disabled={!bannerImage || reservationTimes.length === 0}
+              disabled={
+                !bannerImage ||
+                existingReservationTimes.length +
+                  addedReservationTimes.length ===
+                  0
+              }
             />
           </div>
 
@@ -216,11 +224,13 @@ export default function ActivityPostPage() {
             )}
           </label>
 
+          {/* 예약 시간 추가를 위한 ReservationTimeSelector에 새 배열 전달 */}
           <div>
             <ReservationTimeSelector
-              reservationTimes={reservationTimes}
-              setReservationTimes={setReservationTimes}
+              setAddReservationTimes={setAddedReservationTimes}
               setRemovedReservationIds={setRemovedReservationIds}
+              reservationTimes={existingReservationTimes}
+              setExistingReservationTimes={setExistingReservationTimes}
             />
           </div>
 

--- a/src/app/(primary)/profile/my-activities/post/page.tsx
+++ b/src/app/(primary)/profile/my-activities/post/page.tsx
@@ -205,7 +205,8 @@ export default function ActivityPostPage() {
           <div ref={reservationRef} tabIndex={-1}>
             <ReservationTimeSelector
               reservationTimes={reservationTimes}
-              setReservationTimes={setReservationTimes}
+              setAddReservationTimes={setReservationTimes}
+              setExistingReservationTimes={setReservationTimes}
             />
             {showError && reservationTimes.length === 0 && (
               <p className="text-red-500 text-sm mt-2">

--- a/src/components/pages/activity-post-edit/set-reservation-time.tsx
+++ b/src/components/pages/activity-post-edit/set-reservation-time.tsx
@@ -13,7 +13,10 @@ type ReservationAvailableTime = {
 
 type Props = {
   reservationTimes: ReservationAvailableTime[];
-  setReservationTimes: React.Dispatch<
+  setAddReservationTimes: React.Dispatch<
+    React.SetStateAction<ReservationAvailableTime[]>
+  >;
+  setExistingReservationTimes: React.Dispatch<
     React.SetStateAction<ReservationAvailableTime[]>
   >;
   setRemovedReservationIds?: React.Dispatch<React.SetStateAction<number[]>>;
@@ -21,7 +24,8 @@ type Props = {
 
 export default function ReservationTimeSelector({
   reservationTimes,
-  setReservationTimes,
+  setAddReservationTimes,
+  setExistingReservationTimes,
   setRemovedReservationIds,
 }: Props) {
   const [newReservationTime, setNewReservationTime] =
@@ -92,24 +96,23 @@ export default function ReservationTimeSelector({
       setErrorMessage("이미 겹치는 시간대가 있습니다.");
       return;
     }
-
-    setReservationTimes((prev) => [...prev, newReservationTime]);
+    setExistingReservationTimes((prev) => [...prev, newReservationTime]);
+    setAddReservationTimes((prev) => [...prev, newReservationTime]);
     setNewReservationTime({ date: "", startTime: "", endTime: "" });
     setErrorMessage("");
   };
 
   const removeReservationTime = (index: number) => {
-    if (setRemovedReservationIds) {
+    if (reservationTimes && setRemovedReservationIds) {
       const removedTime = reservationTimes[index];
       if (removedTime.id) {
-        setRemovedReservationIds((prev) =>
-          [...prev, removedTime.id!].filter(
-            (id): id is number => id !== undefined
-          )
+        setRemovedReservationIds((prev) => [...prev, removedTime.id!]);
+        setExistingReservationTimes((prev) =>
+          prev.filter((_, i) => i !== index)
         );
       }
     }
-    setReservationTimes((prev) => prev.filter((_, i) => i !== index));
+    setAddReservationTimes((prev) => prev.filter((_, i) => i !== index));
   };
 
   return (


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- 재영님의 제보로 체험 수정 로직에 오류가 있는 것을 발견했습니다.
- 체험에 예약 대기, 예약 승인 상태에 있는 예약이 있다면, 수정이 불가능했습니다.
  - 원래 로직: 
    - 현재 서버에 있는 예약 시간들을 불러와 삭제 배열에 추가 
    - 그와 동시에 추가할 예약 시간 배열에도 추가하여 서버에 전송
    - (원래 서버에 있었고, 삭제하지 않을 배열들도 삭제 배열에 추가되는 비효율적인 로직으로 작성했었습니다.)
  - 바뀐 로직: 서버에서 불러온 예약 시간들 + 추가 및 삭제 현황을 보여주는 배열 / 삭제 배열(원래 있던 예약 시간들에만 적용) / 서버에 추가할 예약 시간 배열/ 이렇게 3가지 배열을 가지고 효율적으로 관리하도록 수정 하였습니다.
- 정상적으로 작동하는 것 확인했습니다!
- 고도화에서 예약이 있는 시간대는 삭제 버튼이 비활성화 되도록 하겠습니다.

## 📸 스크린샷 / 영상

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
