### PR TITLE
무한스크롤css수정완료

### DIFF
--- a/src/app/(primary)/api/my-activities-api.ts
+++ b/src/app/(primary)/api/my-activities-api.ts
@@ -4,6 +4,7 @@ import {
   ActivityWithSubImagesAndSchedulesDto,
 } from "../../types/activity-schemas";
 import { ReservationResponseDto } from "../../types/reservation-schemas";
+import { MonthlyReservationStat } from "@/app/react-query/my-activity-state";
 
 // 내 체험 리스트 조회
 export const fetchMyActivities = async (
@@ -23,7 +24,7 @@ export const fetchMonthlyReservationStats = async (
   activityId: number,
   year: string,
   month: string
-) => {
+): Promise<MonthlyReservationStat[]> => {
   try {
     const response = await instance.get<
       {
@@ -33,13 +34,18 @@ export const fetchMonthlyReservationStats = async (
     >(`/my-activities/${activityId}/reservation-dashboard`, {
       params: { year, month },
     });
-    return response.data || [];
+
+    return (
+      response.data?.map((stat) => ({
+        ...stat,
+        activityId,
+      })) || []
+    );
   } catch (error) {
     console.error("Failed to fetch reservation stats:", error);
     return [];
   }
 };
-
 // 내 체험 날짜별 예약 정보 조회
 export const fetchDailyReservationStats = async (
   activityId: number,

--- a/src/app/(primary)/profile/my-activities/reservation/page.tsx
+++ b/src/app/(primary)/profile/my-activities/reservation/page.tsx
@@ -119,6 +119,7 @@ export default function ReservationPage() {
           title: label,
           start: format(new Date(stat.date), "yyyy-MM-dd"),
           classNames: ["fc-event", className],
+          eventClassNaems: className,
           extendedProps: { activityId: stat.activityId },
         };
       });
@@ -137,6 +138,7 @@ export default function ReservationPage() {
       setSelectedActivityName(activity.title);
     }
   };
+  console.log("myActivities 데이터:", myActivities);
 
   // 이벤트 클릭 핸들러
   const handleEventClick = async (info: EventClickArg) => {
@@ -241,6 +243,20 @@ export default function ReservationPage() {
               aspectRatio={1.35}
               fixedWeekCount={false}
               showNonCurrentDates={false}
+              eventClassNames={(arg) => {
+                return ["fc-event", arg.event.extendedProps.className];
+              }}
+              dayCellClassNames={(arg) => {
+                if (
+                  events.some(
+                    (event) =>
+                      event.start === arg.date.toISOString().split("T")[0]
+                  )
+                ) {
+                  return ["has-event"];
+                }
+                return [];
+              }}
             />
           </>
         )}

--- a/src/app/(primary)/profile/my-activities/reservation/reservation-modal.tsx
+++ b/src/app/(primary)/profile/my-activities/reservation/reservation-modal.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useState, useMemo } from "react";
+import React, { useState, useMemo, useEffect, useRef } from "react";
 import {
   useReservationsBySchedule,
   useUpdateReservationStatus,
@@ -56,29 +56,36 @@ export default function ReservationModal({
     refetch,
   } = useReservationsBySchedule(activityId ?? 0, selectedScheduleId, activeTab);
 
-  // 데이터가 올바른지 체크 후 배열로 변환
+  // 최신순 정렬
   const reservations: Reservation[] = useMemo(() => {
-    if (!reservationsData || !reservationsData.reservations) return [];
-
-    // 배열인지 확인 후 변환
-    if (Array.isArray(reservationsData.reservations)) {
-      return reservationsData.reservations.map((res) => ({
-        id: res.id ?? 0, // ID 기본값 추가
-        nickname: res.nickname ?? "알 수 없음", // 닉네임 기본값 추가
-        status: res.status as "pending" | "confirmed" | "declined", // 상태 변환 (TS 오류 방지)
-        headCount: res.headCount ?? 0, // 기본 인원 수 설정
-        startTime: res.startTime ?? "", // 시작 시간 기본값 설정
-        endTime: res.endTime ?? "", // 종료 시간 기본값 설정
-        scheduleId: res.scheduleId ?? 0, // 스케줄 ID 기본값 추가
-      }));
+    if (
+      !reservationsData?.reservations ||
+      !Array.isArray(reservationsData.reservations)
+    ) {
+      return [];
     }
 
-    return [];
+    const sorted = [...reservationsData.reservations].sort(
+      (a, b) => b.id - a.id
+    );
+
+    return sorted.map((res) => ({
+      id: res.id ?? 0,
+      nickname: res.nickname ?? "알 수 없음",
+      status: res.status as "pending" | "confirmed" | "declined",
+      headCount: res.headCount ?? 0,
+      startTime: res.startTime ?? "",
+      endTime: res.endTime ?? "",
+      scheduleId: res.scheduleId ?? 0,
+    }));
   }, [reservationsData]);
 
-  // 상태별 예약 개수
+  //  상태별 예약 개수
   const reservationCounts = useMemo(() => {
-    if (!reservationsData || !Array.isArray(reservationsData.reservations)) {
+    if (
+      !reservationsData?.reservations ||
+      !Array.isArray(reservationsData.reservations)
+    ) {
       return { pending: 0, confirmed: 0, declined: 0 };
     }
     return {
@@ -94,14 +101,53 @@ export default function ReservationModal({
     };
   }, [reservationsData]);
 
+  // 현재 탭에 해당하는 예약만 필터링
+  const filteredReservations: Reservation[] = useMemo(() => {
+    return reservations.filter((res) => res.status === activeTab);
+  }, [reservations, activeTab]);
+
+  // 무한 스크롤 관련 state
+  const [displayReservations, setDisplayReservations] = useState<Reservation[]>(
+    []
+  );
+  const [page, setPage] = useState(1);
+  const [hasMore, setHasMore] = useState(true);
+  const listInnerRef = useRef<HTMLDivElement | null>(null);
+
+  // 페이지 단위로 보여줄 데이터 자르기
+  useEffect(() => {
+    const pageSize = 5;
+    const allRes = filteredReservations;
+
+    setDisplayReservations(allRes.slice(0, page * pageSize));
+    setHasMore(allRes.length > page * pageSize);
+  }, [filteredReservations, page]);
+
+  // 스크롤 이벤트
+  const handleScroll = () => {
+    if (!listInnerRef.current) return;
+    const { scrollTop, scrollHeight, clientHeight } = listInnerRef.current;
+    if (scrollTop + clientHeight >= scrollHeight - 10 && hasMore) {
+      setPage((prevPage) => prevPage + 1);
+    }
+  };
+
+  useEffect(() => {
+    const currentRef = listInnerRef.current;
+    if (currentRef) {
+      currentRef.addEventListener("scroll", handleScroll);
+    }
+    return () => {
+      if (currentRef) {
+        currentRef.removeEventListener("scroll", handleScroll);
+      }
+    };
+  }, [hasMore]);
+
+  // 모달이 열려 있지 않으면 렌더링 안 함
   if (!isOpen) return null;
 
-  // 현재 선택된 탭의 예약 리스트 필터링
-  const filteredReservations: Reservation[] = reservations.filter(
-    (res) => res.status === activeTab
-  );
-
-  // 승인하기 버튼 클릭 시 다른 예약 자동 거절
+  //  예약 상태 업데이트
   const handleUpdateStatus = async (
     id: number,
     status: "confirmed" | "declined"
@@ -110,7 +156,7 @@ export default function ReservationModal({
       const latestReservations = await refetch().then(
         (res) => res.data?.reservations || []
       );
-      const reservation = latestReservations.find((res) => res.id === id);
+      const reservation = latestReservations.find((r) => r.id === id);
 
       if (!reservation) {
         alert("해당 예약을 찾을 수 없습니다.");
@@ -127,7 +173,6 @@ export default function ReservationModal({
         reservationId: id,
         status,
       });
-
       return true;
     } catch (error) {
       console.error("예약 상태 변경 중 오류 발생:", error);
@@ -136,23 +181,21 @@ export default function ReservationModal({
     }
   };
 
-  // 승인 버튼 클릭 시, 다른 예약들을 자동 거절 처리
+  // 승인 시 다른 예약 거절 처리
   const handleConfirmReservation = async (reservationId: number) => {
     try {
-      // 선택한 예약을 승인
       const isConfirmed = await handleUpdateStatus(reservationId, "confirmed");
       if (!isConfirmed) return;
 
-      // 최신 데이터 가져오기
+      // 승인 후 최신 데이터 다시 가져오기
       const latestReservations = await refetch().then(
         (res) => res.data?.reservations || []
       );
 
-      // 다른 예약 중 'pending' 상태인 것만 거절
+      // 다른 pending 예약은 모두 거절 처리
       const pendingReservations = latestReservations.filter(
-        (res) => res.id !== reservationId && res.status === "pending"
+        (r) => r.id !== reservationId && r.status === "pending"
       );
-
       for (const res of pendingReservations) {
         await handleUpdateStatus(res.id, "declined");
       }
@@ -194,9 +237,7 @@ export default function ReservationModal({
             ].map(({ key, label, count }) => (
               <button
                 key={key}
-                onClick={() =>
-                  setActiveTab(key as "pending" | "confirmed" | "declined")
-                }
+                onClick={() => setActiveTab(key as typeof activeTab)}
                 className={`relative flex py-3 px-4 text-[2rem] transition-colors duration-200 text-start ${
                   activeTab === key
                     ? "text-nomad-black font-bold"
@@ -216,7 +257,7 @@ export default function ReservationModal({
           <div className="absolute bottom-0 left-0 w-full h-[3px] bg-gray-300"></div>
         </div>
 
-        {/* 예약 날짜 */}
+        {/*  예약 날짜 */}
         <div className="text-left text-nomad-black font-semi-bold text-[2rem] mb-[1.6rem] px-4 mt-[2.7rem]">
           예약 날짜
         </div>
@@ -231,8 +272,8 @@ export default function ReservationModal({
             onChange={(e) => setSelectedScheduleId(Number(e.target.value))}
             className="w-full h-[5.6rem] p-2 border rounded-lg text-[1.6rem]"
           >
-            {reservations.map((res, index) => (
-              <option key={`${res.scheduleId}-${index}`} value={res.scheduleId}>
+            {reservations.map((res, idx) => (
+              <option key={`${res.scheduleId}-${idx}`} value={res.scheduleId}>
                 {res.startTime} ~ {res.endTime}
               </option>
             ))}
@@ -240,25 +281,40 @@ export default function ReservationModal({
         </div>
 
         {/* 예약 내역 */}
-        <div className="px-4">
+        <div ref={listInnerRef} className="px-4 overflow-y-auto max-h-[40rem]">
           <h2 className="text-nomad-black font-semi-bold text-[2rem] mb-3 mt-[2.4rem]">
             예약 내역
           </h2>
 
           {isLoading ? (
             <p className="text-gray-500 text-center py-6">로딩 중...</p>
-          ) : filteredReservations.length > 0 ? (
-            filteredReservations.map((reservation, index) => (
+          ) : displayReservations.length > 0 ? (
+            displayReservations.map((reservation, index) => (
               <div
                 key={`${reservation.id}-${index}`}
-                className="border border-gray-300 border-solid p-4 rounded-lg mb-3 bg-white "
+                className="border border-gray-300 border-solid p-4 rounded-lg mb-3 bg-white"
               >
-                <p className="text-[1.6rem] font-semi-bold text-gray-800">
-                  닉네임: {reservation.nickname}
-                </p>
-                <p className="text-[1.6rem] font-semi-bold pt-[1rem] text-gray-800">
-                  인원 {reservation.headCount}명
-                </p>
+                {/* 예약 정보*/}
+                <div>
+                  <div className="flex gap-2 items-baseline mb-2">
+                    <p className="text-[1.6rem] font-semi-bold text-gray-800">
+                      닉네임
+                    </p>
+                    <p className="text-[1.6rem] font-semi-bold text-black">
+                      {reservation.nickname}
+                    </p>
+                  </div>
+
+                  <div className="flex gap-2 items-baseline">
+                    <p className="text-[1.6rem] font-semi-bold text-gray-800">
+                      인원
+                    </p>
+                    <p className="text-[1.6rem] font-semi-bold text-black">
+                      {reservation.headCount}명
+                    </p>
+                  </div>
+                </div>
+
                 {activeTab === "pending" && (
                   <div className="flex justify-end gap-2 mt-3">
                     <button
@@ -275,6 +331,22 @@ export default function ReservationModal({
                     >
                       거절하기
                     </button>
+                  </div>
+                )}
+
+                {reservation.status === "confirmed" && (
+                  <div className="flex justify-end mt-3">
+                    <div className="bg-[#FFF4E8] text-orange text-[1.4rem] text-center w-[8.2rem] h-[4.4rem] py-[1rem] px-[1.5rem] rounded-md font-bold flex items-center justify-center">
+                      예약 승인
+                    </div>
+                  </div>
+                )}
+
+                {reservation.status === "declined" && (
+                  <div className="flex justify-end mt-3">
+                    <div className="bg-[#FFE4E0] text-red text-[1.4rem] text-center w-[8.2rem] h-[4.4rem] py-[1rem] px-[1.5rem] rounded-md font-bold flex items-center justify-center">
+                      예약 거절
+                    </div>
                   </div>
                 )}
               </div>

--- a/src/app/react-query/my-activity-state.ts
+++ b/src/app/react-query/my-activity-state.ts
@@ -17,7 +17,7 @@ import {
 import { ReservationResponseDto } from "../types/reservation-schemas";
 
 // 월별 예약 현황 타입
-interface MonthlyReservationStat {
+export interface MonthlyReservationStat {
   date: string;
   activityId: number;
   reservations: {
@@ -40,16 +40,16 @@ interface DailyReservationStat {
 }
 
 // 내 체험 리스트 조회
-export const useMyActivities = (cursorId?: number, size = 20) =>
+export const useMyActivities = (cursorId?: number | null, size = 20) =>
   useQuery<{
-    cursorId: number;
+    cursorId: number | null;
     totalCount: number;
     activities: ActivityBasicDto[];
   }>({
-    queryKey: ["myActivities", cursorId],
+    queryKey: ["myActivities", cursorId ?? "null"],
     queryFn: async () => {
       try {
-        return await fetchMyActivities(cursorId, size);
+        return await fetchMyActivities(cursorId ?? null, size);
       } catch (error) {
         if (error instanceof AxiosError) {
           switch (error.response?.status) {
@@ -68,7 +68,7 @@ export const useMyActivities = (cursorId?: number, size = 20) =>
               alert(error.message);
           }
         }
-        throw error;
+        return { cursorId: null, totalCount: 0, activities: [] };
       }
     },
   });

--- a/src/styles/fullcalendar.css
+++ b/src/styles/fullcalendar.css
@@ -96,8 +96,8 @@
   background-color: #1976d2 !important;
 }
 
-.fc-event.confirmed {
-  background-color: #ff7c1d !important;
+.fc-event.confirmed-event {
+  background-color: orange !important;
   color: orange !important;
 }
 


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
> 무한스크롤 구현완료하였습니다
> 멘토링 피드백 반영 완료하였습니다
- [ ]  (캘린더의 예약 부분) a 태그 -> 버튼 태그
- [x]  승인되면 바로 모달 업데이트되어야 함
- [x]  현재는 승인 후 숫자 업데이트 안 되고 승인 부분 눌러야 1로 바뀜
- [ ]  신청 정보 받아오면 ui 로 보여줘야 함 (이 부분은 잘 이해하지못했습니다)
- [x]  한 날짜에 두 명이 예약했을 때 생기는 이슈
- [x]  예약 날짜의 시간 중복되면 하나로 합치게
- [ ]  거절 디자인 없더라도 달력에 알아볼 수 있는 ui 표시해야 할 듯
 ( 이부분은 시도해보았는데 백엔드에서 안되는지 거절은 안나오는것같네요 api상 예약,승인,완료밖에없는것같습니다)


## 📸 스크린샷 / 영상
![image](https://github.com/user-attachments/assets/f3372783-d304-4ced-b909-8e2a8db8da66)
![image](https://github.com/user-attachments/assets/87a52911-3e6c-4563-9034-e81a6ee30c3e)



## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
