### PR TITLE
Features/227 체험 등록 수정 멘토링 피드백 버그 수정

### DIFF
--- a/src/app/(primary)/profile/my-activities/[id]/edit/page.tsx
+++ b/src/app/(primary)/profile/my-activities/[id]/edit/page.tsx
@@ -41,7 +41,6 @@ export default function ActivityEditPage() {
     },
   });
 
-  // 기존 API 예약 시간과 새로 추가할 예약 시간을 분리합니다.
   const [existingReservationTimes, setExistingReservationTimes] = useState<
     ReservationAvailableTime[]
   >([]);
@@ -52,7 +51,15 @@ export default function ActivityEditPage() {
     []
   );
   const [bannerImage, setBannerImage] = useState<string | null>(null);
-  const [introImages, setIntroImages] = useState<string[]>([]);
+
+  const [existingIntroImages, setExistingIntroImages] = useState<
+    { id: number; imageUrl: string }[]
+  >([]);
+  const [newIntroImages, setNewIntroImages] = useState<string[]>([]);
+  const [removedIntroImageIds, setRemovedIntroImageIds] = useState<number[]>(
+    []
+  );
+
   const [modalIsOpen, setModalIsOpen] = useState(false);
 
   const {
@@ -70,9 +77,8 @@ export default function ActivityEditPage() {
       setValue("price", activityDetail.price);
       setValue("address", activityDetail.address);
       setBannerImage(activityDetail.bannerImageUrl);
-      setIntroImages(activityDetail.subImages.map((img) => img.imageUrl));
 
-      // 기존 예약 시간은 따로 관리
+      // 기존 예약 시간 설정
       const initialReservationTimes = activityDetail.schedules.map(
         (schedule) => ({
           id: schedule.id,
@@ -82,6 +88,9 @@ export default function ActivityEditPage() {
         })
       );
       setExistingReservationTimes(initialReservationTimes);
+
+      // 서버에 있는 인트로 이미지는 id와 imageUrl로 관리 (서버 데이터에 id가 있다고 가정)
+      setExistingIntroImages(activityDetail.subImages);
     }
   }, [activityDetail, setValue]);
 
@@ -102,8 +111,8 @@ export default function ActivityEditPage() {
       price: data.price,
       address: data.address,
       bannerImageUrl: bannerImage,
-      subImageUrlsToAdd: introImages,
-      // 새로 추가된 예약 시간만 schedulesToAdd에 포함
+      subImageUrlsToAdd: newIntroImages,
+      subImageIdsToRemove: removedIntroImageIds,
       schedulesToAdd: addedReservationTimes.map(
         ({ date, startTime, endTime }) => ({
           date,
@@ -224,7 +233,6 @@ export default function ActivityEditPage() {
             )}
           </label>
 
-          {/* 예약 시간 추가를 위한 ReservationTimeSelector에 새 배열 전달 */}
           <div>
             <ReservationTimeSelector
               setAddReservationTimes={setAddedReservationTimes}
@@ -241,9 +249,13 @@ export default function ActivityEditPage() {
             />
           </div>
 
+          {/* 인트로 이미지 컴포넌트에 3개의 상태를 props로 전달 */}
           <IntroImagesUploader
-            introImages={introImages}
-            setIntroImages={setIntroImages}
+            existingImages={existingIntroImages}
+            setExistingImages={setExistingIntroImages}
+            newImages={newIntroImages}
+            setNewImages={setNewIntroImages}
+            setRemovedImages={setRemovedIntroImageIds}
           />
         </form>
       </FormProvider>

--- a/src/app/(primary)/profile/my-activities/post/page.tsx
+++ b/src/app/(primary)/profile/my-activities/post/page.tsx
@@ -231,8 +231,8 @@ export default function ActivityPostPage() {
           </div>
 
           <IntroImagesUploader
-            introImages={introImages}
-            setIntroImages={setIntroImages}
+            newImages={introImages}
+            setNewImages={setIntroImages}
           />
         </form>
       </FormProvider>

--- a/src/app/(primary)/profile/my-activities/post/page.tsx
+++ b/src/app/(primary)/profile/my-activities/post/page.tsx
@@ -35,6 +35,9 @@ export default function ActivityPostPage() {
   const [reservationTimes, setReservationTimes] = useState<
     ReservationAvailableTime[]
   >([]);
+  const [addReservationTimes, setAddReservationTimes] = useState<
+    ReservationAvailableTime[]
+  >([]);
   const [modalIsOpen, setModalIsOpen] = useState(false);
   const [showError, setShowError] = useState(false);
 
@@ -73,7 +76,7 @@ export default function ActivityPostPage() {
       address: data.address,
       bannerImageUrl: bannerImage as string,
       subImageUrls: introImages.length > 0 ? introImages : undefined,
-      schedules: reservationTimes.map(({ date, startTime, endTime }) => ({
+      schedules: addReservationTimes.map(({ date, startTime, endTime }) => ({
         date,
         startTime,
         endTime,
@@ -205,7 +208,7 @@ export default function ActivityPostPage() {
           <div ref={reservationRef} tabIndex={-1}>
             <ReservationTimeSelector
               reservationTimes={reservationTimes}
-              setAddReservationTimes={setReservationTimes}
+              setAddReservationTimes={setAddReservationTimes}
               setExistingReservationTimes={setReservationTimes}
             />
             {showError && reservationTimes.length === 0 && (

--- a/src/components/pages/activity-post-edit/banner-image-uploader.tsx
+++ b/src/components/pages/activity-post-edit/banner-image-uploader.tsx
@@ -33,7 +33,7 @@ export default function BannerImageUploader({
             <label className="cursor-pointer w-[18rem] tablet:w-[20.4rem] mobile:w-[16.7rem] h-[18rem] tablet:h-[20.4rem] mobile:h-[16.7rem]">
               <input
                 type="file"
-                accept="image/*"
+                accept="image/png, image/jpeg"
                 onChange={handleBannerUpload}
                 className="hidden"
               />

--- a/src/components/pages/activity-post-edit/intro-image-uploader.tsx
+++ b/src/components/pages/activity-post-edit/intro-image-uploader.tsx
@@ -2,28 +2,38 @@ import Image from "next/image";
 import { useUploadActivityImage } from "@/app/react-query/activity-state";
 
 interface IntroImagesUploaderProps {
-  introImages: string[];
-  setIntroImages: React.Dispatch<React.SetStateAction<string[]>>;
+  existingImages?: { id: number; imageUrl: string }[];
+  setExistingImages?: React.Dispatch<
+    React.SetStateAction<{ id: number; imageUrl: string }[]>
+  >;
+  newImages: string[];
+  setNewImages: React.Dispatch<React.SetStateAction<string[]>>;
+  setRemovedImages?: React.Dispatch<React.SetStateAction<number[]>>;
 }
 
 export default function IntroImagesUploader({
-  introImages,
-  setIntroImages,
+  existingImages = [],
+  setExistingImages,
+  newImages,
+  setNewImages,
+  setRemovedImages,
 }: IntroImagesUploaderProps) {
   const uploadImageMutation = useUploadActivityImage();
 
   const handleIntroUpload = (event: React.ChangeEvent<HTMLInputElement>) => {
     if (event.target.files) {
+      const totalImagesCount = existingImages.length + newImages.length;
+      const maxAllowed = 4;
       const files = Array.from(event.target.files).slice(
         0,
-        4 - introImages.length
+        maxAllowed - totalImagesCount
       );
 
       files.forEach((file) => {
         uploadImageMutation.mutate(file, {
           onSuccess: (uploadedUrl) => {
-            setIntroImages((prev) =>
-              [...prev, uploadedUrl.activityImageUrl].slice(0, 4)
+            setNewImages((prev) =>
+              [...prev, uploadedUrl.activityImageUrl].slice(0, maxAllowed)
             );
           },
         });
@@ -31,8 +41,15 @@ export default function IntroImagesUploader({
     }
   };
 
-  const removeIntroImage = (index: number) => {
-    setIntroImages((prev) => prev.filter((_, i) => i !== index));
+  const removeExistingImage = (id: number) => {
+    if (setExistingImages && setRemovedImages) {
+      setExistingImages((prev) => prev.filter((img) => img.id !== id));
+      setRemovedImages((prev) => [...prev, id]);
+    }
+  };
+
+  const removeNewImage = (index: number) => {
+    setNewImages((prev) => prev.filter((_, i) => i !== index));
   };
 
   return (
@@ -54,7 +71,30 @@ export default function IntroImagesUploader({
             height={204}
           />
         </label>
-        {introImages.map((img, index) => (
+        {existingImages.map((img) => (
+          <div
+            key={img.id}
+            className="relative w-[18rem] tablet:w-[20.4rem] mobile:w-[16.7rem] h-[18rem] tablet:h-[20.4rem] mobile:h-[16.7rem]"
+          >
+            <Image
+              src={img.imageUrl}
+              alt="소개 이미지"
+              layout="fill"
+              objectFit="cover"
+              className="rounded-[2.4rem] border-[0.1rem] border-solid border-black"
+            />
+            {setExistingImages && setRemovedImages && (
+              <button
+                onClick={() => removeExistingImage(img.id)}
+                className="absolute top-[-2rem] tablet:top-[-1rem] mobile:top-[-0.8rem] right-[-2rem] tablet:right-[-1rem] mobile:right-[-0.8rem] bg-[rgba(0,0,0,0.8)] text-white w-[4rem] tablet:w-[3.2rem] mobile:w-[2.4rem] h-[4rem] tablet:h-[3.2rem] mobile:h-[2.4rem] text-xl tablet:text-lg mobile:text-base px-3 py-1 rounded-full"
+                type="button"
+              >
+                X
+              </button>
+            )}
+          </div>
+        ))}
+        {newImages.map((img, index) => (
           <div
             key={index}
             className="relative w-[18rem] tablet:w-[20.4rem] mobile:w-[16.7rem] h-[18rem] tablet:h-[20.4rem] mobile:h-[16.7rem]"
@@ -67,7 +107,7 @@ export default function IntroImagesUploader({
               className="rounded-[2.4rem] border-[0.1rem] border-solid border-black"
             />
             <button
-              onClick={() => removeIntroImage(index)}
+              onClick={() => removeNewImage(index)}
               className="absolute top-[-2rem] tablet:top-[-1rem] mobile:top-[-0.8rem] right-[-2rem] tablet:right-[-1rem] mobile:right-[-0.8rem] bg-[rgba(0,0,0,0.8)] text-white w-[4rem] tablet:w-[3.2rem] mobile:w-[2.4rem] h-[4rem] tablet:h-[3.2rem] mobile:h-[2.4rem] text-xl tablet:text-lg mobile:text-base px-3 py-1 rounded-full"
               type="button"
             >

--- a/src/components/pages/activity-post-edit/set-reservation-time.tsx
+++ b/src/components/pages/activity-post-edit/set-reservation-time.tsx
@@ -38,7 +38,7 @@ export default function ReservationTimeSelector({
   const [filteredEndTimeOptions, setFilteredEndTimeOptions] =
     useState<string[]>(TIME_TABLE);
   const [errorMessage, setErrorMessage] = useState("");
-
+  const [buttonDisable, setButtonDisable] = useState<boolean>(false);
   const filterStartTimeOptions = TIME_TABLE.slice(0, -1);
 
   // 시작 시간 선택 시, 종료 시간 옵션 필터링
@@ -61,17 +61,20 @@ export default function ReservationTimeSelector({
   }, [newReservationTime.startTime]);
 
   const addReservationTime = () => {
+    setButtonDisable(true);
     if (
       !newReservationTime.date ||
       !newReservationTime.startTime ||
       !newReservationTime.endTime
     ) {
       setErrorMessage("모든 값을 입력해주세요.");
+      setButtonDisable(false);
       return;
     }
 
     if (newReservationTime.startTime >= newReservationTime.endTime) {
       setErrorMessage("시작 시간은 종료 시간보다 이전이어야 합니다.");
+      setButtonDisable(false);
       return;
     }
 
@@ -94,16 +97,20 @@ export default function ReservationTimeSelector({
 
     if (isOverlapping) {
       setErrorMessage("이미 겹치는 시간대가 있습니다.");
+      setButtonDisable(false);
       return;
     }
-    setExistingReservationTimes((prev) => [...prev, newReservationTime]);
+    if (setExistingReservationTimes) {
+      setExistingReservationTimes((prev) => [...prev, newReservationTime]);
+    }
     setAddReservationTimes((prev) => [...prev, newReservationTime]);
     setNewReservationTime({ date: "", startTime: "", endTime: "" });
     setErrorMessage("");
+    setButtonDisable(false);
   };
 
   const removeReservationTime = (index: number) => {
-    if (reservationTimes && setRemovedReservationIds) {
+    if (setRemovedReservationIds) {
       const removedTime = reservationTimes[index];
       if (removedTime.id) {
         setRemovedReservationIds((prev) => [...prev, removedTime.id!]);
@@ -164,6 +171,7 @@ export default function ReservationTimeSelector({
               <Button
                 ButtonType="reservationTime"
                 variant="reservationTimeAdd"
+                disabled={buttonDisable}
                 label="+"
                 onClick={addReservationTime}
               />

--- a/src/components/pages/activity-post-edit/time-dropdown.tsx
+++ b/src/components/pages/activity-post-edit/time-dropdown.tsx
@@ -1,5 +1,6 @@
 import { DropdownArrowIcon } from "@/components/common/icons/dropdown-arrow-icon";
 import { DropdownCheckIcon } from "@/components/common/icons/dropdown-check-icon";
+import UseOutsideClick from "@/hooks/use-outside-click";
 import { useState } from "react";
 
 interface SelectDropdownProps {
@@ -16,9 +17,11 @@ export default function TimeDropdown({
   onSelect,
 }: SelectDropdownProps) {
   const [isOpen, setIsOpen] = useState(false);
+  const dropdownRef = UseOutsideClick(() => setIsOpen(false));
 
   return (
     <div
+      ref={dropdownRef}
       className="relative w-full max-w-md"
       onClick={() => setIsOpen(!isOpen)}
     >


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요

- [x] 같은 예약 2번 등록
  - 등록페이지에서 보이는 배열과 서버에 추가할 배열을 따로 놔뒀는데 같은 set함수가 파라미터로 전해지고 있어 시간을 추가했을 때 2개씩 보였습니다. 해당 현상 수정했습니다. 
- [x] 시간 드롭다운 외부 클릭 시 닫힘 기능 추가
- [ ] 배너 이미지 수정 오류 수정
- [x] 인트로 이미지 수정 오류 수정
  - 서버에서 인트로 이미지를 불러와 저장하는 배열 = 서버에 이미지를 추가하는 배열이어서 수정할 때 마다 인트로 이미지가 늘어났던거 였습니다. 
  - 그래서 예약 시간대 버그를 해결했을 때처럼 서버에서 데이터를 불러와 저장하는 배열 / 서버에 이미지를 추가할 배열 / 서버에서 이미지를 삭제할 배열. 이렇게 3개로 나누어 구현했습니다.

배너 이미지 수정 오류는 테스트를 해봤는데 오류가 나지 않아서 일단 펜딩해두고 나중에 재영님 답변 오면 추가해서 작업 하도록 하겠습니다.

## 📸 스크린샷 / 영상
체험 등록 페이지에서 시간 추가했을 때
![image](https://github.com/user-attachments/assets/978b9307-bd1b-422d-aab2-cbcf168d4eb6)

수정 후 다시 수정하기 페이지 들어갔을 때 설명 이미지 수정된 그대로 남아있음
![image](https://github.com/user-attachments/assets/3980e257-7906-4b28-b9d7-79b9a9c36275)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
