### PR TITLE
Fix: 메인 자체 qa 피드백 반영

### DIFF
--- a/src/components/common/ui/pagination.tsx
+++ b/src/components/common/ui/pagination.tsx
@@ -1,5 +1,6 @@
 import Image from "next/image";
 import Link from "next/link";
+import { useCallback, useMemo } from "react";
 
 interface PaginationProps {
   totalPages: number;
@@ -12,18 +13,32 @@ export default function Pagination({
   currentPage,
   setPage,
 }: PaginationProps) {
-  const handlePageChange = (newPage: number) => {
-    if (newPage >= 1 && newPage <= totalPages) {
-      setPage(newPage);
-    }
-  };
-
-  const startPage = Math.max(1, currentPage - 2);
-  const endPage = Math.min(totalPages, startPage + 4);
-  const pages = Array.from(
-    { length: endPage - startPage + 1 },
-    (_, i) => startPage + i
+  const handlePageChange = useCallback(
+    (newPage: number) => {
+      if (newPage >= 1 && newPage <= totalPages) {
+        setPage(newPage);
+      }
+    },
+    [setPage, totalPages]
   );
+
+  const pages = useMemo(() => {
+    const startPage = Math.max(1, currentPage - 2);
+
+    if (totalPages <= 5) {
+      return Array.from({ length: totalPages }, (_, i) => i + 1);
+    }
+    // 1 ~ 5페이지일 경우 정상적으로 표시
+    if (currentPage <= 3) {
+      return Array.from({ length: 5 }, (_, i) => i + 1);
+    }
+    // 마지막 페이지 근처일 경우
+    if (currentPage + 2 >= totalPages) {
+      return Array.from({ length: 5 }, (_, i) => totalPages - 4 + i);
+    }
+    // 나머지 페이지들
+    return Array.from({ length: 5 }, (_, i) => startPage + i);
+  }, [currentPage, totalPages]);
 
   return (
     <div className="mb-[22.2rem] flex-between gap-[1rem]">

--- a/src/components/pages/home/all-activities/all-activities-section.tsx
+++ b/src/components/pages/home/all-activities/all-activities-section.tsx
@@ -5,28 +5,29 @@ import AllActivities from "./all-activities";
 import AllActivitiesTitle from "./all-activities-title";
 import CategoryPriceFilter from "./category-price-filter";
 import { useActivities } from "@/app/react-query/activity-state";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { ErrorIndicator } from "@/components/common/layout/indicator/error-indicator";
 import { CategoryType, SortType } from "@/app/types/activity-schemas";
 import { EmptyContent } from "@/components/common/layout/profile/empty-content";
 import AllActivitiesSkeletonSection from "./all-activites-skeleton-section";
 
-const SIZE = 9;
-
 export default function AllActivitiesSection() {
   const [page, setPage] = useState(1);
   const [category, setCategory] = useState<CategoryType | undefined>(undefined);
   const [sort, setSort] = useState<SortType>(undefined);
+  const [size, setSize] = useState(4);
+
+  // const [windowWidth, setWindowWidth] = useState<number>(window.innerWidth);
 
   const { data, isLoading, isError } = useActivities({
     method: "offset",
     page,
-    size: SIZE,
+    size,
     sort: sort || "latest",
     category,
   });
 
-  const totalPages = Math.ceil((data?.totalCount || 0) / SIZE);
+  const totalPages = Math.ceil((data?.totalCount || 0) / size);
 
   const handleFilterChange = (
     category: CategoryType | undefined,
@@ -36,6 +37,24 @@ export default function AllActivitiesSection() {
     setSort(sort);
     setPage(1);
   };
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 1200) {
+        setSize(8); // 화면이 넓으면 8개
+      } else if (window.innerWidth < 744) {
+        setSize(4); // 화면이 좁으면 4개
+      } else {
+        setSize(6); // 중간 화면 크기에는 6개
+      }
+    };
+    handleResize(); // 처음 로드 시 size 설정
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
 
   return (
     <>

--- a/src/components/pages/home/all-activities/all-activities-section.tsx
+++ b/src/components/pages/home/all-activities/all-activities-section.tsx
@@ -15,9 +15,7 @@ export default function AllActivitiesSection() {
   const [page, setPage] = useState(1);
   const [category, setCategory] = useState<CategoryType | undefined>(undefined);
   const [sort, setSort] = useState<SortType>(undefined);
-  const [size, setSize] = useState(4);
-
-  // const [windowWidth, setWindowWidth] = useState<number>(window.innerWidth);
+  const [size, setSize] = useState(8);
 
   const { data, isLoading, isError } = useActivities({
     method: "offset",

--- a/src/components/pages/home/all-activities/all-activities-section.tsx
+++ b/src/components/pages/home/all-activities/all-activities-section.tsx
@@ -45,7 +45,7 @@ export default function AllActivitiesSection() {
       } else if (window.innerWidth < 744) {
         setSize(4); // 화면이 좁으면 4개
       } else {
-        setSize(6); // 중간 화면 크기에는 6개
+        setSize(9); // 중간 화면 크기에는 6개
       }
     };
     handleResize(); // 처음 로드 시 size 설정

--- a/src/components/pages/home/all-activities/all-activities.tsx
+++ b/src/components/pages/home/all-activities/all-activities.tsx
@@ -11,8 +11,8 @@ export default function AllActivities({ activities }: AllActivitiesProps) {
     <ul
       className="grid grid-cols-4 gap-[2rem] w-[120rem] mb-[6rem]
     tablet:w-[69.5rem] tablet:gap-[3.2rem] tablet:grid-cols-3
-    mobile:grid-cols-2 mobile:grid-rows-2 mobile:grid-auto-rows-[1fr]
-    mobile:w-[38.8rem] mobile:mb-[4.6rem] mobile:px-[2rem] mobile:gap-[1.6rem]"
+    mobile:grid-cols-2 mobile:grid-auto-rows-[1fr]
+    mobile:w-[34.3rem] mobile:mb-[4.6rem] mobile:gap-[1.6rem]"
     >
       {activities.map((activity) => (
         <li

--- a/src/components/pages/home/all-activities/all-activities.tsx
+++ b/src/components/pages/home/all-activities/all-activities.tsx
@@ -1,35 +1,12 @@
 import { ActivityBasicDto } from "@/app/types/activity-schemas";
 import Image from "next/image";
 import Link from "next/link";
-import { useEffect, useState } from "react";
 
 interface AllActivitiesProps {
   activities: ActivityBasicDto[];
 }
 
 export default function AllActivities({ activities }: AllActivitiesProps) {
-  const [windowWidth, setWindowWidth] = useState<number>(0);
-
-  useEffect(() => {
-    const handleResize = () => {
-      setWindowWidth(window.innerWidth);
-    };
-
-    window.addEventListener("resize", handleResize);
-    setWindowWidth(window.innerWidth);
-
-    return () => {
-      window.removeEventListener("resize", handleResize);
-    };
-  }, []);
-
-  const displayedActivities =
-    windowWidth >= 1200
-      ? activities.slice(0, 8)
-      : windowWidth < 744
-        ? activities.slice(0, 4)
-        : activities;
-
   return (
     <ul
       className="grid grid-cols-4 gap-[2rem] w-[120rem] mb-[6rem]
@@ -37,7 +14,7 @@ export default function AllActivities({ activities }: AllActivitiesProps) {
     mobile:grid-cols-2 mobile:grid-rows-2 mobile:grid-auto-rows-[1fr]
     mobile:w-[38.8rem] mobile:mb-[4.6rem] mobile:px-[2rem] mobile:gap-[1.6rem]"
     >
-      {displayedActivities.map((activity) => (
+      {activities.map((activity) => (
         <li
           key={activity.id}
           className="rounded-[2rem] flex-column gap-[1.6rem]"

--- a/src/components/pages/home/popular-activities/popular-activities-section.tsx
+++ b/src/components/pages/home/popular-activities/popular-activities-section.tsx
@@ -131,7 +131,7 @@ export default function PopularActivitiesSection() {
         </div>
       </div>
 
-      {isLoading || isFetchingNextPage ? (
+      {isLoading ? (
         <div
           className="flex flex-nowrap gap-[2.4rem] w-[120rem] mb-[6rem] overflow-x-auto hide-scrollbar
         tablet:w-[78rem] tablet:ml-[2.4rem] tablet:gap-[3.2rem]

--- a/src/components/pages/home/search/activity-explorer.tsx
+++ b/src/components/pages/home/search/activity-explorer.tsx
@@ -19,7 +19,6 @@ const isLastCharHasBatchim = (text: string): boolean => {
 };
 
 const CONFIG = {
-  SIZE: 16,
   SUFFIX_WITH_BATCHIM: "으로 ",
   SUFFIX_WITHOUT_BATCHIM: "로 ",
 };
@@ -28,11 +27,12 @@ export default function ActivityExplorer() {
   const [searchQuery, setSearchQuery] = useState<string>("");
   const [submittedQuery, setSubmittedQuery] = useState<string>("");
   const [page, setPage] = useState(1);
+  const [size, setSize] = useState(0);
 
   const { data, isLoading, isError } = useActivities({
     method: "offset",
     page,
-    size: CONFIG.SIZE,
+    size: size,
     ...(submittedQuery && { keyword: submittedQuery }),
   });
 
@@ -48,7 +48,7 @@ export default function ActivityExplorer() {
 
   const activities = data?.activities ?? [];
 
-  const totalPages = Math.ceil((data?.totalCount || 0) / CONFIG.SIZE);
+  const totalPages = Math.ceil((data?.totalCount || 0) / size);
 
   const suffix = isLastCharHasBatchim(submittedQuery)
     ? CONFIG.SUFFIX_WITH_BATCHIM
@@ -59,6 +59,24 @@ export default function ActivityExplorer() {
       setSubmittedQuery("");
     }
   }, [searchQuery]);
+
+  useEffect(() => {
+    const handleResize = () => {
+      if (window.innerWidth >= 1200) {
+        setSize(16); // 화면이 넓으면 8개
+      } else if (window.innerWidth < 744) {
+        setSize(8); // 화면이 좁으면 4개
+      } else {
+        setSize(9); // 중간 화면 크기에는 6개
+      }
+    };
+    handleResize(); // 처음 로드 시 size 설정
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
 
   return (
     <div className="flex-column desktop:w-[120rem]">

--- a/src/components/pages/home/search/activity-explorer.tsx
+++ b/src/components/pages/home/search/activity-explorer.tsx
@@ -50,7 +50,7 @@ export default function ActivityExplorer() {
 
   const totalPages = Math.ceil((data?.totalCount || 0) / CONFIG.SIZE);
 
-  const suffix = isLastCharHasBatchim(searchQuery)
+  const suffix = isLastCharHasBatchim(submittedQuery)
     ? CONFIG.SUFFIX_WITH_BATCHIM
     : CONFIG.SUFFIX_WITHOUT_BATCHIM;
 


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
>
> ex) 와인 상세 페이지 컴포넌트 추가, 와인 데이터 API 호출 로직 추가, 상세 페이지 스타일 수정

(오전에 정리한 것 모두 완료)
- [x] 검색어에 따른 조사 변경 로직 수정(입력할 때마다 조사 부분만 바뀌고 있었음, 앞 단어는 그대로.)
- [x] 인기 체험 스크롤 오류 해결
- [x] 페이지네이션 기능, CSS 오류 해결
  - 평소에 5개 보이다가 마지막 페이지면 페이지 버튼 3개만 보이는 것
  - 버튼 누를 때마다 깜빡이는 것
  - 모바일에서 중간 데이터 유실된 채로 안 보이던 것
- [x] 모바일에서 검색 시 체험 개수에 따라 높이, 레이아웃 조정

## 📸 스크린샷 / 영상

(데이터 유실 오류 해결)
![image](https://github.com/user-attachments/assets/dd72871a-1789-4652-ad99-be5647f07064)

![image](https://github.com/user-attachments/assets/b28ed8e6-c157-4dd4-8522-3bf44e3fe1d0)

![image](https://github.com/user-attachments/assets/099784c5-c76d-41f7-bb5e-478004441617)


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
