### PR TITLE
Style: 인기 체험 이미지 불투명도 추가 & 체험 상세 이미지 너비 값 추가

### DIFF
--- a/src/app/react-query/user-state.ts
+++ b/src/app/react-query/user-state.ts
@@ -33,7 +33,6 @@ export const useCreateUser = () => {
             break;
           case 409:
             console.error("중복된 이메일입니다.");
-            alert(errorMessage);
             break;
           default:
             console.error("회원가입 중 알 수 없는 오류가 발생했습니다.");

--- a/src/components/pages/activity-detail/activity-images.tsx
+++ b/src/components/pages/activity-detail/activity-images.tsx
@@ -108,7 +108,7 @@ export default function ActivityImages() {
           ) : (
             <div
               className="w-[119.8rem] h-[53.4rem] flex gap-[0.8rem] mb-[8.5rem]
-        tablet:w-[69.6rem] tablet:h-[31rem] tablet:mb-[3.2rem]"
+        tablet:w-[69.6rem] tablet:h-[31rem] mobile:w-full tablet:mb-[3.2rem]"
             >
               <Image
                 src={activity!.bannerImageUrl}

--- a/src/components/pages/home/popular-activities/popular-activities-section.tsx
+++ b/src/components/pages/home/popular-activities/popular-activities-section.tsx
@@ -168,42 +168,44 @@ export default function PopularActivitiesSection() {
           mobile:w-[18.4rem] mobile:h-[18.4rem]"
               >
                 <Link href={`/activity/${activity.id}`}>
-                  <Image
-                    src={activity.bannerImageUrl}
-                    alt={activity.title}
-                    width={384}
-                    height={384}
-                    className="absolute inset-0 w-full h-full rounded-[2rem] object-cover"
-                  />
                   <div
-                    className="flex-column items-start w-full gap-[2rem] px-[2rem] py-[3rem]
+                    className="h-full w-full bg-center bg-cover rounded-[2rem]"
+                    style={{
+                      backgroundImage: `url(${activity.bannerImageUrl})`,
+                    }}
+                  >
+                    <div className="absolute inset-0 bg-black opacity-20 rounded-[2rem]" />
+                    <div
+                      className="flex-column items-start w-full gap-[2rem] px-[2rem] py-[3rem]
           absolute transform -translate-x-1/2 translate-y-0 bottom-0 left-1/2 text-white
           mobile:pt-[3rem] mobile:pr-[2rem] mobile:pb-[1.2rem] mobile:gap-[0.5rem]"
-                  >
-                    <div className="flex-between gap-[0.5rem]">
-                      <Image
-                        src="/image/rating-star.svg"
-                        alt="평균 별점 아이콘"
-                        width={18}
-                        height={18}
-                      />
-                      <p className="text-md font-semiBold">
-                        {activity.rating} (
-                        {Number(activity.reviewCount).toLocaleString("ko-KR")})
+                    >
+                      <div className="flex-between gap-[0.5rem]">
+                        <Image
+                          src="/image/rating-star.svg"
+                          alt="평균 별점 아이콘"
+                          width={18}
+                          height={18}
+                        />
+                        <p className="text-md font-semiBold">
+                          {activity.rating} (
+                          {Number(activity.reviewCount).toLocaleString("ko-KR")}
+                          )
+                        </p>
+                      </div>
+                      <p
+                        className="text-3xl font-bold break-keep
+              mobile:text-[1.8rem] mobile:leading-[2.6rem]"
+                      >
+                        {activity.title}
+                      </p>
+                      <p className="text-xl font-bold flex-between gap-[0.5rem]">
+                        ₩ {Number(activity.price).toLocaleString("ko-KR")}
+                        <span className="text-md font-regular text-gray-700">
+                          /인
+                        </span>
                       </p>
                     </div>
-                    <p
-                      className="text-3xl font-bold break-keep
-              mobile:text-[1.8rem] mobile:leading-[2.6rem]"
-                    >
-                      {activity.title}
-                    </p>
-                    <p className="text-xl font-bold flex-between gap-[0.5rem]">
-                      ₩ {Number(activity.price).toLocaleString("ko-KR")}
-                      <span className="text-md font-regular text-gray-700">
-                        /인
-                      </span>
-                    </p>
                   </div>
                 </Link>
               </li>


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
>
> ex) 와인 상세 페이지 컴포넌트 추가, 와인 데이터 API 호출 로직 추가, 상세 페이지 스타일 수정

- 인기 체험 이미지에 불투명도를 추가해 가시성 높임
- 체험 상세 이미지의 모바일 너비를 명시해 디바이스 전환 시 생기는 레이아웃 깨짐 현상 해결

## 📸 스크린샷 / 영상

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
