### PR TITLE
Refactor: 스크롤 후 현재 위치 계산하는 로직에 디바운싱 추가

### DIFF
--- a/src/app/(primary)/layout.tsx
+++ b/src/app/(primary)/layout.tsx
@@ -8,8 +8,9 @@ import Script from "next/script";
 const KAKAO_MAP = process.env.NEXT_PUBLIC_KAKAO_MAP_APP_KEY;
 
 export const metadata: Metadata = {
-  title: "GlobalNomad",
-  description: "당신의 일상을 특별하게 만드는 한 번의 클릭",
+  title: "특별한 이색 체험, 원데이 클래스를 찾을 수 있는 곳 | GlobalNomad",
+  description:
+    "당신의 일상을 특별하게 만드는 한 번의 클릭. 원데이 클래스, 여행 가이드, 동아리, 체험 입장권 등 다양한 체험 상품들을 예약할 수 있습니다.",
   icons: "/logo.svg",
 };
 

--- a/src/components/pages/activity-detail/kakomaps/kakaomaps.tsx
+++ b/src/components/pages/activity-detail/kakomaps/kakaomaps.tsx
@@ -1,9 +1,6 @@
 import { useEffect } from "react";
 import MarkerInfo from "./markerInfo";
 import ReactDOMServer from "react-dom/server";
-// import Script from "next/script";
-
-// const KAKAO_MAP = process.env.NEXT_PUBLIC_KAKAO_MAP_APP_KEY;
 
 interface GeocodeResult {
   x: string;
@@ -80,10 +77,6 @@ export default function KakaoMaps({ address }: KakaoMapsProps) {
 
   return (
     <>
-      {/* <Script
-        type="text/javascript"
-        src={`//dapi.kakao.com/v2/maps/sdk.js?appkey=${KAKAO_MAP}&autoload=false&libraries=services`}
-      /> */}
       <div
         id="map"
         className="w-[79rem] h-[45rem] rounded-[1.6rem]

--- a/src/components/pages/home/popular-activities/popular-activities-section.tsx
+++ b/src/components/pages/home/popular-activities/popular-activities-section.tsx
@@ -4,6 +4,7 @@ import Image from "next/image";
 import Link from "next/link";
 import { useInView } from "react-intersection-observer";
 import { useEffect, useMemo, useRef, useState } from "react";
+import { useDebounce } from "use-debounce";
 
 const SIZE = 9;
 
@@ -35,6 +36,18 @@ export default function PopularActivitiesSection() {
     triggerOnce: true,
   });
 
+  const handleScroll = () => {
+    if (scrollContainerRef.current) {
+      const scrollContainer = scrollContainerRef.current;
+      const itemWidth = itemRefs.current[0]?.offsetWidth || 0;
+      const newStartIndex = Math.floor(scrollContainer.scrollLeft / itemWidth);
+
+      setStartIndex(newStartIndex);
+    }
+  };
+
+  const [debouncedHandleScroll] = useDebounce(handleScroll, 200);
+
   useEffect(() => {
     if (inView && hasNextPage && !isLoading) {
       fetchNextPage();
@@ -42,25 +55,13 @@ export default function PopularActivitiesSection() {
   }, [inView, fetchNextPage, hasNextPage, isLoading]);
 
   useEffect(() => {
-    const handleScroll = () => {
-      if (scrollContainerRef.current) {
-        const scrollContainer = scrollContainerRef.current;
-        const itemWidth = itemRefs.current[0]?.offsetWidth || 0;
-        const newStartIndex = Math.floor(
-          scrollContainer.scrollLeft / itemWidth
-        );
-
-        setStartIndex(newStartIndex);
-      }
-    };
-
     const scrollContainer = scrollContainerRef.current;
-    scrollContainer?.addEventListener("scroll", handleScroll);
+    scrollContainer?.addEventListener("scroll", debouncedHandleScroll);
 
     return () => {
-      scrollContainer?.removeEventListener("scroll", handleScroll);
+      scrollContainer?.removeEventListener("scroll", debouncedHandleScroll);
     };
-  }, [activities]);
+  }, [debouncedHandleScroll]);
 
   const scrollToIndex = (index: number) => {
     const targetElement = itemRefs.current[index];


### PR DESCRIPTION
## 📝작업 내용

> 이번 PR에서 작업한 내용을 간략히 설명해주세요
>
> ex) 와인 상세 페이지 컴포넌트 추가, 와인 데이터 API 호출 로직 추가, 상세 페이지 스타일 수정

- 무한 스크롤과 페이지네이션 동시 유지 위해, 스크롤하면 스크롤한 너비를 통해 현재 인덱스(체험 목록 몇 번째인지) 계산했음
- 스크롤 할 때마다 연산하고 있었음
- 디바운싱 처리를 통해, 마지막으로 스크롤 움직였을 때 연산하도록 변경

- 자잘하게 메타 데이터 추가와 주석 삭제도 함

## 📸 스크린샷 / 영상

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?

- 
